### PR TITLE
Add bugreport module

### DIFF
--- a/adb/adb.go
+++ b/adb/adb.go
@@ -91,6 +91,13 @@ func (a *ADB) Backup(arg string) error {
 	return cmd.Run()
 }
 
+// Bugreport generates a bugreport of the the device
+func (a *ADB) Bugreport() error {
+	cmd := exec.Command(a.ExePath, "bugreport", "bugreport.zip")
+	err := cmd.Run()
+	return err
+}
+
 // check if file exists
 func (a *ADB) FileExists(path string) (bool, error) {
 	out, err := a.Shell("[", "-f", path, "] || echo 1")

--- a/modules/bugreport.go
+++ b/modules/bugreport.go
@@ -1,0 +1,63 @@
+// androidqf - Android Quick Forensics
+// Copyright (c) 2021-2023 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+package modules
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/mvt-project/androidqf/acquisition"
+	"github.com/mvt-project/androidqf/adb"
+	"github.com/mvt-project/androidqf/log"
+)
+
+type Bugreport struct {
+	StoragePath string
+}
+
+func NewBugreport() *Bugreport {
+	return &Bugreport{}
+}
+
+func (b *Bugreport) Name() string {
+	return "bugreport"
+}
+
+func (b *Bugreport) InitStorage(storagePath string) error {
+	b.StoragePath = storagePath
+	return nil
+}
+
+func (b *Bugreport) Run(acq *acquisition.Acquisition, fast bool) error {
+
+	log.Info(
+		"Generating a bugreport for the device...",
+	)
+
+	err := adb.Client.Bugreport()
+	if err != nil {
+		log.Debugf("Impossible to generate bugreport: %w", err)
+		return err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Debugf("Impossible to get current directory: %w", err)
+		return err
+	}
+
+	origBugreportPath := filepath.Join(cwd, "bugreport.zip")
+	bugreportPath := filepath.Join(b.StoragePath, "bugreport.zip")
+
+	err = os.Rename(origBugreportPath, bugreportPath)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Bugreport completed!")
+
+	return nil
+}

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -21,6 +21,7 @@ type Module interface {
 func List() []Module {
 	return []Module{
 		NewBackup(),
+		NewBugreport(),
 		NewPackages(),
 		NewGetProp(),
 		NewDumpsys(),


### PR DESCRIPTION
This adds a new module to AndroidQF to generate bugreports. MVT already supports checking bugreports.