### PR TITLE
Rust collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ collector:
 	@echo "Copying collector binaries to assets folder."
 	cp android-collector/build/collector_* $(ASSETS_FOLDER)
 
+collector-rs:
+	@mkdir -p $(BUILD_FOLDER)
+	@echo "Building Android collector-rs..."
+	cd android-collector-rs && RUSTFLAGS="-Clink-arg=-z -Clink-arg=nostart-stop-gc" cargo ndk -t aarch64-linux-android build --release
+	@echo "Finished building collector."
+	@echo "Copying collector binaries to assets folder."
+	cp android-collector-rs/target/aarch64-linux-android/release/android-collector-rs $(ASSETS_FOLDER)
+
 windows:
 	@mkdir -p $(BUILD_FOLDER)
 
@@ -62,9 +70,6 @@ windows:
 	@cp $(PLATFORMTOOLS_FOLDER)/AdbWinUsbApi.dll $(ASSETS_FOLDER)
 	@cp $(PLATFORMTOOLS_FOLDER)/adb.exe $(ASSETS_FOLDER)
 
-	@echo "[builder] Building Windows binary for amd64"
-
-	$(FLAGS_WINDOWS) go build --ldflags '$(LD_FLAGS) -extldflags "-static"' -o $(BUILD_FOLDER)/androidqf_windows_amd64.exe .
 
 	@echo "[builder] Done!"
 
@@ -80,11 +85,6 @@ darwin:
 	@cd /tmp && unzip -u $(PLATFORMTOOLS_DARWIN)
 	@cp $(PLATFORMTOOLS_FOLDER)/adb $(ASSETS_FOLDER)
 
-	@echo "[builder] Building Darwin binary for amd64"
-
-	$(FLAGS_DARWIN) GOARCH=amd64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_darwin_amd64 .
-	$(FLAGS_DARWIN) GOARCH=arm64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_darwin_arm64 .
-
 	@echo "[builder] Done!"
 
 linux:
@@ -98,11 +98,6 @@ linux:
 	@rm -rf $(PLATFORMTOOLS_FOLDER)
 	@cd /tmp && unzip -u $(PLATFORMTOOLS_LINUX)
 	@cp $(PLATFORMTOOLS_FOLDER)/adb $(ASSETS_FOLDER)
-
-	@echo "[builder] Building Linux binary for amd64"
-
-	@$(FLAGS_LINUX) GOARCH=amd64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_linux_amd64 .
-	@$(FLAGS_LINUX) GOARCH=arm64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_linux_arm64 .
 
 	@echo "[builder] Done!"
 
@@ -127,9 +122,9 @@ download:
 	@cd /tmp && unzip -u $(PLATFORMTOOLS_DARWIN)
 	@cp $(PLATFORMTOOLS_FOLDER)/adb $(ASSETS_FOLDER)
 
-all: collector windows darwin linux
+all: collector-rs windows darwin linux
 
 clean:
 	rm -rf $(BUILD_FOLDER)
 	rm -f $(ASSETS_FOLDER)/adb $(ASSETS_FOLDER)/adb.exe $(ASSETS_FOLDER)/AdbWinApi.dll $(ASSETS_FOLDER)/AdbWinUsbApi.dll rm -f $(ASSETS_FOLDER)/collector_*
-	cd android-collector && $(MAKE) clean
+	cd android-collector-rs && cargo clean

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ collector-rs:
 	cd android-collector-rs && RUSTFLAGS="-Clink-arg=-z -Clink-arg=nostart-stop-gc" cargo ndk -t aarch64-linux-android build --release
 	@echo "Finished building collector."
 	@echo "Copying collector binaries to assets folder."
-	cp android-collector-rs/target/aarch64-linux-android/release/android-collector-rs $(ASSETS_FOLDER)
+	cp android-collector-rs/target/aarch64-linux-android/release/android-collector-rs $(ASSETS_FOLDER)/collector_arm64
 
 windows:
 	@mkdir -p $(BUILD_FOLDER)
@@ -70,6 +70,9 @@ windows:
 	@cp $(PLATFORMTOOLS_FOLDER)/AdbWinUsbApi.dll $(ASSETS_FOLDER)
 	@cp $(PLATFORMTOOLS_FOLDER)/adb.exe $(ASSETS_FOLDER)
 
+	@echo "[builder] Building Windows binary for amd64"
+
+	$(FLAGS_WINDOWS) go build --ldflags '$(LD_FLAGS) -extldflags "-static"' -o $(BUILD_FOLDER)/androidqf_windows_amd64.exe .
 
 	@echo "[builder] Done!"
 
@@ -85,6 +88,11 @@ darwin:
 	@cd /tmp && unzip -u $(PLATFORMTOOLS_DARWIN)
 	@cp $(PLATFORMTOOLS_FOLDER)/adb $(ASSETS_FOLDER)
 
+	@echo "[builder] Building Darwin binary for amd64"
+
+	$(FLAGS_DARWIN) GOARCH=amd64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_darwin_amd64 .
+	$(FLAGS_DARWIN) GOARCH=arm64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_darwin_arm64 .
+
 	@echo "[builder] Done!"
 
 linux:
@@ -98,6 +106,11 @@ linux:
 	@rm -rf $(PLATFORMTOOLS_FOLDER)
 	@cd /tmp && unzip -u $(PLATFORMTOOLS_LINUX)
 	@cp $(PLATFORMTOOLS_FOLDER)/adb $(ASSETS_FOLDER)
+
+	@echo "[builder] Building Linux binary for amd64"
+
+	@$(FLAGS_LINUX) GOARCH=amd64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_linux_amd64 .
+	@$(FLAGS_LINUX) GOARCH=arm64 go build --ldflags '$(LD_FLAGS)' -o $(BUILD_FOLDER)/androidqf_linux_arm64 .
 
 	@echo "[builder] Done!"
 
@@ -126,5 +139,5 @@ all: collector-rs windows darwin linux
 
 clean:
 	rm -rf $(BUILD_FOLDER)
-	rm -f $(ASSETS_FOLDER)/adb $(ASSETS_FOLDER)/adb.exe $(ASSETS_FOLDER)/AdbWinApi.dll $(ASSETS_FOLDER)/AdbWinUsbApi.dll rm -f $(ASSETS_FOLDER)/collector_*
+	rm -f $(ASSETS_FOLDER)/adb $(ASSETS_FOLDER)/adb.exe $(ASSETS_FOLDER)/AdbWinApi.dll $(ASSETS_FOLDER)/AdbWinUsbApi.dll rm -f $(ASSETS_FOLDER)/android-collector*
 	cd android-collector-rs && cargo clean

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can then compile AndroidQF for your platform of choice:
     make darwin
     make windows
 
-These commands will generate binaries in a *build/* folder.
+These commands will generate binaries in a _build/_ folder.
 
 ## How to use
 
@@ -40,20 +40,20 @@ Now androidqf should be executing and creating an acquisition folder at the same
 
 The following data can be extracted:
 
-| Data | Optional? | Output path(s) |
-|------|-----------|----------------|
-| A full backup or backup of SMS and MMS messages. | :white_check_mark: | `backup.ab` |
-| The output of the getprop shell command, providing build information and configuration parameters. | |  `getprop.txt` |
-| All system settings | | `settings_*.txt` |
-| The output of the ps shell command, providing a list of all running processes. | | `processes.txt` |
-| The list of system's services. | | `services.txt` |
-| A copy of all the logs from the system. | | `logs/`, `logcat.txt` |
-| The output of the dumpsys shell command, providing diagnostic information about the device. | | `dumpsys.txt` |
-| A list of all packages installed and related distribution files. | |  `packages.json` |
-| Copy of all installed APKs or of only those not marked as system apps. | ✅ | `apks/*` |
-| A list of files on the system. | | `files.json` |
-| A copy of the files available in temp folders. | | `tmp/*` |
-| A bug report containing system and app-specific logs, with no private data included. | | `bugreport.zip` |
+| Data                                                                                               | Optional?          | Output path(s)        |
+| -------------------------------------------------------------------------------------------------- | ------------------ | --------------------- |
+| A full backup or backup of SMS and MMS messages.                                                   | :white_check_mark: | `backup.ab`           |
+| The output of the getprop shell command, providing build information and configuration parameters. |                    | `getprop.txt`         |
+| All system settings                                                                                |                    | `settings_*.txt`      |
+| The output of the ps shell command or the collector, providing a list of all running processes.    |                    | `processes.txt`       |
+| The list of system's services.                                                                     |                    | `services.txt`        |
+| A copy of all the logs from the system.                                                            |                    | `logs/`, `logcat.txt` |
+| The output of the dumpsys shell command, providing diagnostic information about the device.        |                    | `dumpsys.txt`         |
+| A list of all packages installed and related distribution files.                                   |                    | `packages.json`       |
+| Copy of all installed APKs or of only those not marked as system apps.                             | :white_check_mark: | `apks/*`              |
+| The output of the find shell command or the collector, providing a list of files on the system.    |                    | `files.json`          |
+| A copy of the files available in temp folders.                                                     |                    | `tmp/*`               |
+| A bug report containing system and app-specific logs, with no private data included.               |                    | `bugreport.zip`       |
 
 ### About optional data collection
 
@@ -72,11 +72,11 @@ Would you like to take a backup of the device?
 
 These options refers to data collected from the device by running the `adb backup` command in the background. If `No backup` is selected, the `adb backup` command is not run.
 
-| Option | Explanation |
-|--------|-------------|
-| Only SMS | `adb backup com.android.providers.telephony` is run. Only data from `com.android.providers.telephony` is collected. This includes the SMS database. |
-| Everything | `adb backup -all` is run. This requests backups of only apps that have explicitly allowed backups of their data via this method. Since Android 12+, this method doesn’t extract anything for almost all apps.|
-| No backup | `adb backup` is not run |
+| Option     | Explanation                                                                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Only SMS   | `adb backup com.android.providers.telephony` is run. Only data from `com.android.providers.telephony` is collected. This includes the SMS database.                                                           |
+| Everything | `adb backup -all` is run. This requests backups of only apps that have explicitly allowed backups of their data via this method. Since Android 12+, this method doesn’t extract anything for almost all apps. |
+| No backup  | `adb backup` is not run                                                                                                                                                                                       |
 
 ### Downloading copies of apps
 
@@ -89,12 +89,11 @@ Would you like to download copies of all apps or only non-system ones?
     Do not download any
 ```
 
-| Option | Explanation |
-|--------|-------------|
-| All | All installed packages will be retrieved from the phone |
+| Option                   | Explanation                                                     |
+| ------------------------ | --------------------------------------------------------------- |
+| All                      | All installed packages will be retrieved from the phone         |
 | Only non-system packages | Don't download any packages listed in `adb pm list packages -s` |
-| Do not download any | Don't download any packages |
-
+| Do not download any      | Don't download any packages                                     |
 
 ## Encryption & Potential Threats
 
@@ -116,6 +115,6 @@ Bear in mind, it is always possible that at least some portion of the unencrypte
 
 ## License
 
-The purpose of androidqf is to facilitate the ***consensual forensic analysis*** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want androidqf to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of androidqf (and any other software licensed the same) for the purpose of *adversarial forensics*.
+The purpose of androidqf is to facilitate the **_consensual forensic analysis_** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want androidqf to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of androidqf (and any other software licensed the same) for the purpose of _adversarial forensics_.
 
-In order to achieve this androidqf is released under [MVT License 1.1](https://license.mvt.re/1.1/), an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any *"Larger Work"* derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (*"Data Owner"*).
+In order to achieve this androidqf is released under [MVT License 1.1](https://license.mvt.re/1.1/), an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any _"Larger Work"_ derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (_"Data Owner"_).

--- a/adb/collector.go
+++ b/adb/collector.go
@@ -169,8 +169,6 @@ func (c *Collector) Find(path string) ([]FileInfo, error) {
 		}
 	}
 
-	log.Debug(results)
-
 	return results, nil
 }
 

--- a/adb/collector.go
+++ b/adb/collector.go
@@ -154,7 +154,7 @@ func (c *Collector) Find(path string) ([]FileInfo, error) {
 		}
 	}
 
-	out, err := c.Adb.Shell(c.ExePath, "find", "--path", path)
+	out, err := c.Adb.Shell(c.ExePath, "find", "--path", path, "--exclude_dir", "/proc/**", "--exclude_dir", "/sys/**")
 	if err != nil {
 		return results, err
 	}

--- a/adb/collector.go
+++ b/adb/collector.go
@@ -214,8 +214,6 @@ func (c *Collector) Processes() ([]ProcessInfo, error) {
 		return results, err
 	}
 
-	log.Debug(out)
-
 	err = json.Unmarshal([]byte(out), &results)
 	if err != nil {
 		return results, err

--- a/adb/collector.go
+++ b/adb/collector.go
@@ -111,7 +111,7 @@ func (c *Collector) Install() error {
 		return fmt.Errorf("unsupported architecture for collector: %s", c.Architecture)
 	}
 
-	log.Debugf("Deploying collector binary '%s' for architecture '%s'.", collectorName, c.Architecture)
+	log.Debugf("Deploying collector binary '%s' for architecture '%s' in '%s'.", collectorName, c.Architecture, c.ExePath)
 	collectorBinary, err := assets.Collector.ReadFile(collectorName)
 	if err != nil {
 		// Somehow the file doesn't exist
@@ -154,16 +154,19 @@ func (c *Collector) Find(path string) ([]FileInfo, error) {
 		}
 	}
 
-	out, err := c.Adb.Shell(c.ExePath, "find", path)
+	out, err := c.Adb.Shell(c.ExePath, "find", "--path", path)
 	if err != nil {
 		return results, err
 	}
+
 	for _, line := range strings.Split(out, "\n") {
 		err = json.Unmarshal([]byte(line), &file)
 		if err == nil {
 			results = append(results, file)
 		}
 	}
+
+	log.Debug(results)
 
 	return results, nil
 }
@@ -209,6 +212,9 @@ func (c *Collector) Processes() ([]ProcessInfo, error) {
 	if err != nil {
 		return results, err
 	}
+
+	log.Debug(out)
+
 	err = json.Unmarshal([]byte(out), &results)
 	if err != nil {
 		return results, err

--- a/adb/collector.go
+++ b/adb/collector.go
@@ -160,7 +160,10 @@ func (c *Collector) Find(path string) ([]FileInfo, error) {
 	}
 
 	for _, line := range strings.Split(out, "\n") {
+		log.Info(line)
 		err = json.Unmarshal([]byte(line), &file)
+
+		log.Info(err)
 		if err == nil {
 			results = append(results, file)
 		}

--- a/android-collector-rs/Cargo.toml
+++ b/android-collector-rs/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "android-collector-rs"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+log = "0.4.21"
+env_logger = { version = "0.11.8", features = ["auto-color"] }
+clap = { version = "4.5.35", features = ["cargo", "derive"] }
+yara-x = { version = "0.14.0" }
+globwalk = "0.9.1"
+crossbeam = "0.8"
+serde_json = { version = "1.0.140", features = ["preserve_order"] }
+serde = { version = "1.0.219", features = ["derive"] }
+jwalk-meta = "0.9"
+wild = "2.2.1"
+flume = "0.11"
+glob-sl = "0.4"
+sha2 = "0.11.0-pre.5"
+base16ct = { version = "0.2", features = ["alloc"] }
+procfs = "0.17.0"
+
+# An example of a custom profile
+[profile.release]
+strip = true      # Automatically strip symbols from the binary.
+opt-level = "z"   # Optimize for size.
+lto = true        # Enable link time optimization
+codegen-units = 1 # Reduce parallel code generation units
+panic = "abort"

--- a/android-collector-rs/Cargo.toml
+++ b/android-collector-rs/Cargo.toml
@@ -17,11 +17,10 @@ jwalk-meta = "0.9"
 wild = "2.2.1"
 flume = "0.11"
 glob-sl = "0.4"
-sha2 = "0.11.0-pre.5"
+sha2 = { version = "0.10.9", default-features = true }
 base16ct = { version = "0.2", features = ["alloc"] }
 procfs = "0.17.0"
 
-# An example of a custom profile
 [profile.release]
 strip = true      # Automatically strip symbols from the binary.
 opt-level = "z"   # Optimize for size.

--- a/android-collector-rs/README.md
+++ b/android-collector-rs/README.md
@@ -1,0 +1,1 @@
+RUSTFLAGS="-Clink-arg=-z -Clink-arg=nostart-stop-gc" cargo ndk -t aarch64-linux-android build --release

--- a/android-collector-rs/README.md
+++ b/android-collector-rs/README.md
@@ -1,1 +1,10 @@
+# Android Rust Collector
+
+## Deps:
+
+export ANDROID_NDK_HOME="/path"
+rustup target add aarch64-linux-android
+cargo install cargo-ndk
+
+## Compile for aarch64
 RUSTFLAGS="-Clink-arg=-z -Clink-arg=nostart-stop-gc" cargo ndk -t aarch64-linux-android build --release

--- a/android-collector-rs/README.md
+++ b/android-collector-rs/README.md
@@ -1,5 +1,7 @@
 # Android Rust Collector
 
+# Copyright (c) 2025 Anthony Desnos.
+
 ## Deps:
 
 export ANDROID_NDK_HOME="/path"
@@ -7,4 +9,5 @@ rustup target add aarch64-linux-android
 cargo install cargo-ndk
 
 ## Compile for aarch64
+
 RUSTFLAGS="-Clink-arg=-z -Clink-arg=nostart-stop-gc" cargo ndk -t aarch64-linux-android build --release

--- a/android-collector-rs/src/cmd.rs
+++ b/android-collector-rs/src/cmd.rs
@@ -1,4 +1,4 @@
-use clap::{command, crate_authors, Arg, ArgAction, ArgMatches, Command, ValueEnum};
+use clap::{command, crate_authors, Command};
 
 use crate::files;
 use crate::process;

--- a/android-collector-rs/src/cmd.rs
+++ b/android-collector-rs/src/cmd.rs
@@ -1,4 +1,4 @@
-use clap::{command, crate_authors, Command};
+use clap::{command, Command};
 
 use crate::files;
 use crate::process;
@@ -16,13 +16,9 @@ pub fn command(name: &'static str) -> Command {
 }
 
 pub fn cli() -> Command {
-    command!()
-        .author(crate_authors!("\n")) // requires `cargo` feature
-        .arg_required_else_help(true)
-        .subcommand_required(true)
-        .subcommands(vec![
-            yara::yara_cmds(),
-            files::files_cmds(),
-            process::process_cmds(),
-        ])
+    command!().subcommand_required(true).subcommands(vec![
+        files::files_find_cmd(),
+        process::process_ps_cmd(),
+        yara::yara_cmd(),
+    ])
 }

--- a/android-collector-rs/src/cmd.rs
+++ b/android-collector-rs/src/cmd.rs
@@ -1,0 +1,28 @@
+use clap::{command, crate_authors, Arg, ArgAction, ArgMatches, Command, ValueEnum};
+
+use crate::files;
+use crate::process;
+use crate::yara;
+
+pub fn command(name: &'static str) -> Command {
+    Command::new(name).help_template(
+        r#"{about-with-newline}
+{usage-heading}
+  {usage}
+
+{all-args}
+"#,
+    )
+}
+
+pub fn cli() -> Command {
+    command!()
+        .author(crate_authors!("\n")) // requires `cargo` feature
+        .arg_required_else_help(true)
+        .subcommand_required(true)
+        .subcommands(vec![
+            yara::yara_cmds(),
+            files::files_cmds(),
+            process::process_cmds(),
+        ])
+}

--- a/android-collector-rs/src/cmd_help.rs
+++ b/android-collector-rs/src/cmd_help.rs
@@ -1,0 +1,8 @@
+pub const YARA_SCAN_LONG_HELP: &str = r#"Scan a file or directory with Yara-x
+"#;
+
+pub const FILES_FIND_LONG_HELP: &str = r#"Get the list of files with details
+"#;
+
+pub const PROCESS_LONG_HELP: &str = r#"Get the list of processes with details
+"#;

--- a/android-collector-rs/src/files/mod.rs
+++ b/android-collector-rs/src/files/mod.rs
@@ -1,0 +1,39 @@
+pub mod scandir;
+pub mod scandir_result;
+
+use clap::{arg, value_parser, ArgMatches, Command};
+use log::info;
+
+use crate::cmd;
+use crate::cmd_help;
+
+use scandir::Scandir;
+
+pub fn files_cmds() -> Command {
+    cmd::command("find")
+        .about("List all files from a specific path with their attributes")
+        .long_about(cmd_help::FILES_FIND_LONG_HELP)
+        .arg(
+            arg!(-p --"path" <PATH>)
+                .help("Scan the specific PATH")
+                .value_parser(value_parser!(String)),
+        )
+}
+
+pub fn exec_find(args: &ArgMatches) -> anyhow::Result<()> {
+    info!("EXEC FIND");
+
+    let scan = Scandir::new(args.get_one::<String>("path").unwrap(), None)?
+        .dir_exclude(Some(vec![
+            "/proc/**".to_string(),
+            "/sys/**".to_string(),
+            "/system/**".to_string(),
+        ]))
+        .max_depth(5)
+        .follow_links(false)
+        .collect()?;
+
+    println!("{:?}", scan.to_json().unwrap());
+
+    Ok(())
+}

--- a/android-collector-rs/src/files/mod.rs
+++ b/android-collector-rs/src/files/mod.rs
@@ -10,13 +10,13 @@ use crate::cmd_help;
 
 use scandir::Scandir;
 
-pub fn files_cmds() -> Command {
+pub fn files_find_cmd() -> Command {
     cmd::command("find")
         .about("List all files from a specific path with their attributes")
         .long_about(cmd_help::FILES_FIND_LONG_HELP)
         .arg(
             arg!(-p --"path" <PATH>)
-                .help("Scan the specific PATH")
+                .help("Scan the provided directory or file path")
                 .value_parser(value_parser!(String)),
         )
 }
@@ -42,7 +42,7 @@ pub struct AndroidQFFileInfo {
 }
 
 pub fn exec_find(args: &ArgMatches) -> anyhow::Result<()> {
-    info!("EXEC FIND");
+    info!("[collector][files][find]");
 
     let scan = Scandir::new(args.get_one::<String>("path").unwrap(), None)?
         .dir_exclude(Some(vec!["/proc/**".to_string(), "/sys/**".to_string()]))

--- a/android-collector-rs/src/files/mod.rs
+++ b/android-collector-rs/src/files/mod.rs
@@ -22,7 +22,7 @@ pub fn files_cmds() -> Command {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct MVTFileInfo {
+pub struct AndroidQFFileInfo {
     path: String,
     size: u64,
     mode: String,
@@ -52,17 +52,17 @@ pub fn exec_find(args: &ArgMatches) -> anyhow::Result<()> {
 
     // Get the scans and convert to struct compatible with AndroidQF, in order to keep compatibility
     for file in scan.results {
-        let m = MVTFileInfo {
+        let m = AndroidQFFileInfo {
             path: file.path().clone(),
             size: file.size(),
             mode: "".to_string(),
-            user_id: 0,
+            user_id: file.uid(),
             user_name: "".to_string(),
-            group_id: 0,
+            group_id: file.gid(),
             group_name: "".to_string(),
-            changed_time: 0,
-            modified_time: 0,
-            access_time: 0,
+            changed_time: file.ctime() as i64,
+            modified_time: file.mtime() as i64,
+            access_time: file.atime() as i64,
             error: "".to_string(),
             context: "".to_string(),
             sha1: "".to_string(),

--- a/android-collector-rs/src/files/mod.rs
+++ b/android-collector-rs/src/files/mod.rs
@@ -24,16 +24,14 @@ pub fn exec_find(args: &ArgMatches) -> anyhow::Result<()> {
     info!("EXEC FIND");
 
     let scan = Scandir::new(args.get_one::<String>("path").unwrap(), None)?
-        .dir_exclude(Some(vec![
-            "/proc/**".to_string(),
-            "/sys/**".to_string(),
-            "/system/**".to_string(),
-        ]))
+        .dir_exclude(Some(vec!["/proc/**".to_string(), "/sys/**".to_string()]))
         .max_depth(5)
         .follow_links(false)
         .collect()?;
 
-    println!("{:?}", scan.to_json().unwrap());
-
+    // Get the scans and convert to something compatible with AndroidQF
+    for file in scan.results {
+        println!("{:?}", file.to_json().unwrap());
+    }
     Ok(())
 }

--- a/android-collector-rs/src/files/mod.rs
+++ b/android-collector-rs/src/files/mod.rs
@@ -3,6 +3,7 @@ pub mod scandir_result;
 
 use clap::{arg, value_parser, ArgMatches, Command};
 use log::info;
+use serde::{Deserialize, Serialize};
 
 use crate::cmd;
 use crate::cmd_help;
@@ -20,6 +21,26 @@ pub fn files_cmds() -> Command {
         )
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct MVTFileInfo {
+    path: String,
+    size: u64,
+    mode: String,
+    user_id: u32,
+    user_name: String,
+    group_id: u32,
+    group_name: String,
+    changed_time: i64,
+    modified_time: i64,
+    access_time: i64,
+    error: String,
+    context: String,
+    sha1: String,
+    sha256: String,
+    sha512: String,
+    md5: String,
+}
+
 pub fn exec_find(args: &ArgMatches) -> anyhow::Result<()> {
     info!("EXEC FIND");
 
@@ -29,9 +50,28 @@ pub fn exec_find(args: &ArgMatches) -> anyhow::Result<()> {
         .follow_links(false)
         .collect()?;
 
-    // Get the scans and convert to something compatible with AndroidQF
+    // Get the scans and convert to struct compatible with AndroidQF, in order to keep compatibility
     for file in scan.results {
-        println!("{:?}", file.to_json().unwrap());
+        let m = MVTFileInfo {
+            path: file.path().clone(),
+            size: file.size(),
+            mode: "".to_string(),
+            user_id: 0,
+            user_name: "".to_string(),
+            group_id: 0,
+            group_name: "".to_string(),
+            changed_time: 0,
+            modified_time: 0,
+            access_time: 0,
+            error: "".to_string(),
+            context: "".to_string(),
+            sha1: "".to_string(),
+            sha256: file.digest().clone(),
+            sha512: "".to_string(),
+            md5: "".to_string(),
+        };
+
+        println!("{}", serde_json::to_string(&m).unwrap());
     }
     Ok(())
 }

--- a/android-collector-rs/src/files/scandir.rs
+++ b/android-collector-rs/src/files/scandir.rs
@@ -32,8 +32,6 @@ pub fn get_root_path_len(root_path: &Path) -> usize {
 fn create_entry(
     dir_entry: &jwalk_meta::DirEntry<((), Option<Result<Metadata, Error>>)>,
 ) -> ScandirResult {
-    //
-
     let file_type = dir_entry.file_type;
     let mut st_ctime: Option<SystemTime> = None;
     let mut st_mtime: Option<SystemTime> = None;

--- a/android-collector-rs/src/files/scandir.rs
+++ b/android-collector-rs/src/files/scandir.rs
@@ -1,0 +1,480 @@
+use jwalk_meta::WalkDirGeneric;
+use sha2::{Digest, Sha256};
+use std::{fs, io};
+
+use flume::{unbounded, Receiver, Sender};
+use std::fs::canonicalize;
+use std::fs::Metadata;
+use std::io::Error;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Instant, SystemTime};
+
+use crate::files::scandir_result::{ScandirResult, ScandirResults};
+use crate::helper::direntry::DirEntry;
+use crate::helper::filter::{create_filter, filter_children, Filter};
+use crate::helper::options::Options;
+use crate::helper::ErrorsType;
+
+pub fn get_root_path_len(root_path: &Path) -> usize {
+    let root_path = root_path.to_str().unwrap();
+    let mut root_path_len = root_path.len();
+    if !root_path.ends_with('/') {
+        root_path_len += 1;
+    }
+    root_path_len
+}
+
+#[inline]
+fn create_entry(
+    root_path_len: usize,
+    dir_entry: &jwalk_meta::DirEntry<((), Option<Result<Metadata, Error>>)>,
+) -> ScandirResult {
+    //
+
+    let file_type = dir_entry.file_type;
+    let mut st_ctime: Option<SystemTime> = None;
+    let mut st_mtime: Option<SystemTime> = None;
+    let mut st_atime: Option<SystemTime> = None;
+    let mut st_mode: u32 = 0;
+    let mut st_ino: u64 = 0;
+    let mut st_dev: u64 = 0;
+    let mut st_nlink: u64 = 0;
+    let mut st_size: u64 = 0;
+    let mut st_blksize: u64 = 4096;
+    let mut st_blocks: u64 = 0;
+    let mut st_uid: u32 = 0;
+    let mut st_gid: u32 = 0;
+    let mut st_rdev: u64 = 0;
+
+    if let Some(ref metadata) = dir_entry.metadata {
+        st_ctime = metadata.created;
+        st_mtime = metadata.modified;
+        st_atime = metadata.accessed;
+        st_size = metadata.size;
+        if let Some(ref metadata) = dir_entry.metadata_ext {
+            {
+                st_mode = metadata.st_mode;
+                st_ino = metadata.st_ino;
+                st_dev = metadata.st_dev;
+                st_nlink = metadata.st_nlink;
+                st_blksize = metadata.st_blksize;
+                st_blocks = metadata.st_blocks;
+                st_uid = metadata.st_uid;
+                st_gid = metadata.st_gid;
+                st_rdev = metadata.st_rdev;
+            }
+        }
+    }
+    let is_file = file_type.is_file();
+    let path_str = dir_entry.parent_path.to_str().unwrap();
+    let mut path = if path_str.len() > root_path_len {
+        PathBuf::from(&path_str[root_path_len..])
+    } else {
+        PathBuf::new()
+    };
+
+    path.push(&dir_entry.file_name);
+
+    let mut digest = String::from("");
+    if file_type.is_file() {
+        let path = String::from(dir_entry.path().to_str().unwrap());
+
+        /*
+        let mut scanner = Scanner::new(rules_ref);
+
+        let scan_results = scanner.scan_file(path.clone()).unwrap();
+        println!(
+            "PATH {:?} RES = {:?}",
+            path,
+            scan_results.matching_rules().len()
+        );*/
+
+        digest = match &mut fs::File::open(&path) {
+            Err(_) => String::from(""),
+            Ok(file) => {
+                let mut hasher = Sha256::new();
+                let _n = io::copy(file, &mut hasher);
+                let hash = hasher.finalize();
+                let hex_hash = base16ct::lower::encode_string(&hash);
+                hex_hash.to_string()
+            }
+        };
+    }
+
+    let entry: ScandirResult = ScandirResult::DirEntry(DirEntry {
+        path: path.to_str().unwrap().to_string(),
+        is_symlink: file_type.is_symlink(),
+        is_dir: file_type.is_dir(),
+        is_file,
+        digest,
+        st_ctime,
+        st_mtime,
+        st_atime,
+        st_mode,
+        st_ino,
+        st_dev,
+        st_nlink,
+        st_size,
+        st_blksize,
+        st_blocks,
+        st_uid,
+        st_gid,
+        st_rdev,
+    });
+    entry
+}
+
+fn entries_thread(
+    options: Options,
+    filter: Option<Filter>,
+    tx: Sender<ScandirResult>,
+    stop: Arc<AtomicBool>,
+) {
+    //    let file_yara = fs::File::open("/data/local/tmp/output.yarc").unwrap();
+    //    let rules = Rules::deserialize_from(file_yara).unwrap();
+    //    let rules_ref = &rules;
+
+    let root_path_len = get_root_path_len(&options.root_path);
+
+    let dir_entry = jwalk_meta::DirEntry::from_path(
+        0,
+        &options.root_path,
+        true,
+        true,
+        options.follow_links,
+        Arc::new(Vec::new()),
+    )
+    .unwrap();
+
+    if !dir_entry.file_type.is_dir() {
+        let _ = tx.send(create_entry(root_path_len, &dir_entry));
+        return;
+    }
+
+    let max_file_cnt = options.max_file_cnt;
+    let mut file_cnt = 0;
+
+    for result in WalkDirGeneric::new(&options.root_path)
+        .skip_hidden(options.skip_hidden)
+        .follow_links(options.follow_links)
+        .sort(options.sorted)
+        .max_depth(options.max_depth)
+        .read_metadata(true)
+        .process_read_dir(move |_, root_dir, _, children| {
+            if let Some(root_dir) = root_dir.to_str() {
+                if root_dir.len() + 1 < root_path_len {
+                    return;
+                }
+            } else {
+                return;
+            }
+            filter_children(children, &filter);
+            children.iter_mut().for_each(|dir_entry_result| {
+                if let Ok(dir_entry) = dir_entry_result {
+                    if tx.send(create_entry(root_path_len, dir_entry)).is_err() {
+                        return;
+                    }
+                }
+            });
+        })
+    {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        if let Ok(dir_entry) = result {
+            if !dir_entry.file_type.is_dir() {
+                file_cnt += 1;
+                if max_file_cnt > 0 && file_cnt > max_file_cnt {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Scandir {
+    // Options
+    options: Options,
+    store: bool,
+    // Results
+    entries: ScandirResults,
+    duration: Arc<Mutex<f64>>,
+    finished: Arc<AtomicBool>,
+    // Internal
+    thr: Option<thread::JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
+    rx: Option<Receiver<ScandirResult>>,
+}
+
+impl Scandir {
+    pub fn new<P: AsRef<Path>>(root_path: P, store: Option<bool>) -> Result<Self, Error> {
+        Ok(Scandir {
+            options: Options {
+                root_path: canonicalize(root_path.as_ref().to_str().unwrap())?,
+                sorted: false,
+                skip_hidden: false,
+                max_depth: usize::MAX,
+                max_file_cnt: usize::MAX,
+                dir_include: None,
+                dir_exclude: None,
+                file_include: None,
+                file_exclude: None,
+                case_sensitive: false,
+                follow_links: false,
+            },
+            store: store.unwrap_or(true),
+            entries: ScandirResults::new(),
+            duration: Arc::new(Mutex::new(0.0)),
+            finished: Arc::new(AtomicBool::new(false)),
+            thr: None,
+            stop: Arc::new(AtomicBool::new(false)),
+            rx: None,
+        })
+    }
+
+    /// Return results in sorted order.
+    pub fn sorted(mut self, sorted: bool) -> Self {
+        self.options.sorted = sorted;
+        self
+    }
+
+    /// Skip hidden entries. Enabled by default.
+    pub fn skip_hidden(mut self, skip_hidden: bool) -> Self {
+        self.options.skip_hidden = skip_hidden;
+        self
+    }
+
+    /// Set the maximum depth of entries yield by the iterator.
+    ///
+    /// The smallest depth is `0` and always corresponds to the path given
+    /// to the `new` function on this type. Its direct descendents have depth
+    /// `1`, and their descendents have depth `2`, and so on.
+    ///
+    /// Note that this will not simply filter the entries of the iterator, but
+    /// it will actually avoid descending into directories when the depth is
+    /// exceeded.
+    pub fn max_depth(mut self, depth: usize) -> Self {
+        self.options.max_depth = match depth {
+            0 => usize::MAX,
+            _ => depth,
+        };
+        self
+    }
+
+    /// Set maximum number of files to collect
+    pub fn max_file_cnt(mut self, max_file_cnt: usize) -> Self {
+        self.options.max_file_cnt = match max_file_cnt {
+            0 => usize::MAX,
+            _ => max_file_cnt,
+        };
+        self
+    }
+
+    /// Set directory include filter
+    pub fn dir_include(mut self, dir_include: Option<Vec<String>>) -> Self {
+        self.options.dir_include = dir_include;
+        self
+    }
+
+    /// Set directory exclude filter
+    pub fn dir_exclude(mut self, dir_exclude: Option<Vec<String>>) -> Self {
+        self.options.dir_exclude = dir_exclude;
+        self
+    }
+
+    /// Set file include filter
+    pub fn file_include(mut self, file_include: Option<Vec<String>>) -> Self {
+        self.options.file_include = file_include;
+        self
+    }
+
+    /// Set file exclude filter
+    pub fn file_exclude(mut self, file_exclude: Option<Vec<String>>) -> Self {
+        self.options.file_exclude = file_exclude;
+        self
+    }
+
+    /// Set case sensitive filename filtering
+    pub fn case_sensitive(mut self, case_sensitive: bool) -> Self {
+        self.options.case_sensitive = case_sensitive;
+        self
+    }
+
+    /// Set follow symlinks
+    pub fn follow_links(mut self, follow_links: bool) -> Self {
+        self.options.follow_links = follow_links;
+        self
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        *self.duration.lock().unwrap() = 0.0;
+    }
+
+    pub fn start(&mut self) -> Result<(), Error> {
+        if self.busy() {
+            return Err(Error::other("Busy"));
+        }
+
+        self.clear();
+        let options = self.options.clone();
+        let filter = create_filter(&options)?;
+        let (tx, rx) = unbounded();
+        self.rx = Some(rx);
+        self.stop.store(false, Ordering::Relaxed);
+        let stop = self.stop.clone();
+        let duration = self.duration.clone();
+        let finished = self.finished.clone();
+        self.thr = Some(thread::spawn(move || {
+            let start_time = Instant::now();
+            entries_thread(options, filter, tx, stop);
+            *duration.lock().unwrap() = start_time.elapsed().as_secs_f64();
+            finished.store(true, Ordering::Relaxed);
+        }));
+        Ok(())
+    }
+
+    pub fn join(&mut self) -> bool {
+        if let Some(thr) = self.thr.take() {
+            if let Err(_e) = thr.join() {
+                return false;
+            }
+            return true;
+        }
+        false
+    }
+
+    pub fn stop(&mut self) -> bool {
+        if let Some(thr) = self.thr.take() {
+            self.stop.store(true, Ordering::Relaxed);
+            if let Err(_e) = thr.join() {
+                return false;
+            }
+            return true;
+        }
+        false
+    }
+
+    pub fn collect(&mut self) -> Result<ScandirResults, Error> {
+        if !self.finished() {
+            if !self.busy() {
+                self.start()?;
+            }
+            self.join();
+        }
+        Ok(self.results(true))
+    }
+
+    pub fn has_results(&mut self, only_new: bool) -> bool {
+        if let Some(ref rx) = self.rx {
+            if !rx.is_empty() {
+                return true;
+            }
+        }
+        if only_new {
+            return false;
+        }
+        !self.entries.is_empty()
+    }
+
+    pub fn results_cnt(&mut self, only_new: bool) -> usize {
+        if let Some(ref rx) = self.rx {
+            if only_new {
+                rx.len()
+            } else {
+                self.entries.len() + rx.len()
+            }
+        } else if only_new {
+            0
+        } else {
+            self.entries.len()
+        }
+    }
+
+    pub fn results(&mut self, only_new: bool) -> ScandirResults {
+        let mut results = ScandirResults::new();
+        if let Some(ref rx) = self.rx {
+            while let Ok(entry) = rx.try_recv() {
+                if let ScandirResult::Error(e) = entry {
+                    results.errors.push(e);
+                } else {
+                    results.results.push(entry);
+                }
+            }
+        }
+        if self.store {
+            self.entries.extend(&results);
+        }
+        if !only_new && self.store {
+            return self.entries.clone();
+        }
+        results
+    }
+
+    pub fn has_entries(&mut self, only_new: bool) -> bool {
+        if let Some(ref rx) = self.rx {
+            if !rx.is_empty() {
+                return true;
+            }
+        }
+        if only_new {
+            return false;
+        }
+        !self.entries.is_empty()
+    }
+
+    pub fn entries_cnt(&mut self, only_new: bool) -> usize {
+        if let Some(ref rx) = self.rx {
+            if only_new {
+                return rx.len();
+            }
+            self.entries.len() + rx.len()
+        } else {
+            self.entries.len()
+        }
+    }
+
+    pub fn entries(&mut self, only_new: bool) -> Vec<ScandirResult> {
+        self.results(only_new).results
+    }
+
+    pub fn has_errors(&mut self) -> bool {
+        !self.entries.errors.is_empty()
+    }
+
+    pub fn errors_cnt(&mut self) -> usize {
+        self.entries.errors.len()
+    }
+
+    pub fn errors(&mut self, only_new: bool) -> ErrorsType {
+        self.results(only_new).errors
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        self.entries.to_json()
+    }
+
+    pub fn duration(&mut self) -> f64 {
+        *self.duration.lock().unwrap()
+    }
+
+    pub fn finished(&mut self) -> bool {
+        self.finished.load(Ordering::Relaxed)
+    }
+
+    pub fn busy(&self) -> bool {
+        if let Some(ref thr) = self.thr {
+            !thr.is_finished()
+        } else {
+            false
+        }
+    }
+
+    pub fn options(&self) -> Options {
+        self.options.clone()
+    }
+}

--- a/android-collector-rs/src/files/scandir.rs
+++ b/android-collector-rs/src/files/scandir.rs
@@ -1,6 +1,7 @@
 use jwalk_meta::WalkDirGeneric;
 use sha2::{Digest, Sha256};
-use std::{fs, io};
+use std::fs;
+use std::io;
 
 use flume::{unbounded, Receiver, Sender};
 use std::fs::canonicalize;
@@ -81,16 +82,6 @@ fn create_entry(
     let mut digest = String::from("");
     if file_type.is_file() {
         let path = String::from(dir_entry.path().to_str().unwrap());
-
-        /*
-        let mut scanner = Scanner::new(rules_ref);
-
-        let scan_results = scanner.scan_file(path.clone()).unwrap();
-        println!(
-            "PATH {:?} RES = {:?}",
-            path,
-            scan_results.matching_rules().len()
-        );*/
 
         digest = match &mut fs::File::open(&path) {
             Err(_) => String::from(""),

--- a/android-collector-rs/src/files/scandir_result.rs
+++ b/android-collector-rs/src/files/scandir_result.rs
@@ -11,6 +11,14 @@ pub enum ScandirResult {
 
 impl ScandirResult {
     #[inline]
+    pub fn digest(&self) -> &String {
+        match self {
+            Self::DirEntry(e) => &e.digest,
+            Self::Error(e) => &e.0,
+        }
+    }
+
+    #[inline]
     pub fn path(&self) -> &String {
         match self {
             Self::DirEntry(e) => &e.path,

--- a/android-collector-rs/src/files/scandir_result.rs
+++ b/android-collector-rs/src/files/scandir_result.rs
@@ -1,0 +1,133 @@
+use serde::{Deserialize, Serialize};
+
+use crate::helper::direntry::DirEntry;
+use crate::helper::ErrorsType;
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub enum ScandirResult {
+    DirEntry(DirEntry),
+    Error((String, String)),
+}
+
+impl ScandirResult {
+    #[inline]
+    pub fn path(&self) -> &String {
+        match self {
+            Self::DirEntry(e) => &e.path,
+            Self::Error(e) => &e.0,
+        }
+    }
+
+    #[inline]
+    pub fn error(&self) -> Option<&(String, String)> {
+        match self {
+            Self::Error(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_dir(&self) -> bool {
+        match self {
+            Self::DirEntry(e) => e.is_dir,
+            Self::Error(_) => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_file(&self) -> bool {
+        match self {
+            Self::DirEntry(e) => e.is_file,
+            Self::Error(_) => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_symlink(&self) -> bool {
+        match self {
+            Self::DirEntry(e) => e.is_symlink,
+            Self::Error(_) => false,
+        }
+    }
+
+    #[inline]
+    pub fn ctime(&self) -> f64 {
+        match self {
+            Self::DirEntry(e) => e.ctime(),
+            Self::Error(_) => 0.0,
+        }
+    }
+
+    #[inline]
+    pub fn mtime(&self) -> f64 {
+        match self {
+            Self::DirEntry(e) => e.mtime(),
+            Self::Error(_) => 0.0,
+        }
+    }
+
+    #[inline]
+    pub fn atime(&self) -> f64 {
+        match self {
+            Self::DirEntry(e) => e.atime(),
+            Self::Error(_) => 0.0,
+        }
+    }
+
+    #[inline]
+    pub fn size(&self) -> u64 {
+        match self {
+            Self::DirEntry(e) => e.st_size,
+            Self::Error(_) => 0,
+        }
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct ScandirResults {
+    pub results: Vec<ScandirResult>,
+    pub errors: ErrorsType,
+}
+
+impl ScandirResults {
+    pub fn new() -> Self {
+        ScandirResults {
+            results: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.results.clear();
+        self.errors.clear();
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty() && self.errors.is_empty()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.results.len() + self.errors.len()
+    }
+
+    pub fn extend(&mut self, results: &ScandirResults) {
+        self.results.extend_from_slice(&results.results);
+        self.errors.extend_from_slice(&results.errors);
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}
+
+impl Default for ScandirResults {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/android-collector-rs/src/files/scandir_result.rs
+++ b/android-collector-rs/src/files/scandir_result.rs
@@ -90,6 +90,22 @@ impl ScandirResult {
         }
     }
 
+    #[inline]
+    pub fn uid(&self) -> u32 {
+        match self {
+            Self::DirEntry(e) => e.st_uid,
+            Self::Error(_) => 0,
+        }
+    }
+
+    #[inline]
+    pub fn gid(&self) -> u32 {
+        match self {
+            Self::DirEntry(e) => e.st_gid,
+            Self::Error(_) => 0,
+        }
+    }
+
     pub fn to_json(&self) -> serde_json::Result<String> {
         serde_json::to_string(self)
     }

--- a/android-collector-rs/src/helper/direntry.rs
+++ b/android-collector-rs/src/helper/direntry.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
+pub struct DirEntry {
+    pub path: String,
+    pub is_symlink: bool,
+    pub is_dir: bool,
+    pub is_file: bool,
+    pub digest: String,
+    /// Creation time in seconds as float
+    pub st_ctime: Option<SystemTime>,
+    /// Modification time in seconds as float
+    pub st_mtime: Option<SystemTime>,
+    /// Access time in seconds as float
+    pub st_atime: Option<SystemTime>,
+    /// Size of file / entry
+    pub st_size: u64,
+    /// File system block size
+    pub st_blksize: u64,
+    /// Number of used blocks on device / file system
+    pub st_blocks: u64,
+    /// File access mode / rights
+    pub st_mode: u32,
+    /// Number of hardlinks
+    pub st_nlink: u64,
+    /// User ID (Unix only)
+    pub st_uid: u32,
+    /// Group ID (Unix only)
+    pub st_gid: u32,
+    /// I-Node number (Unix only)
+    pub st_ino: u64,
+    /// Device number (Unix only)
+    pub st_dev: u64,
+    /// Device number (for character and block devices on Unix).
+    pub st_rdev: u64,
+}
+
+impl DirEntry {
+    #[inline]
+    pub fn ctime(&self) -> f64 {
+        let duration = self
+            .st_ctime
+            .unwrap_or(UNIX_EPOCH)
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_err| Duration::new(0, 0));
+        (duration.as_secs() as f64) + (duration.subsec_nanos() as f64) * 1e-9
+    }
+
+    #[inline]
+    pub fn mtime(&self) -> f64 {
+        let duration = self
+            .st_mtime
+            .unwrap_or(UNIX_EPOCH)
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_err| Duration::new(0, 0));
+        (duration.as_secs() as f64) + (duration.subsec_nanos() as f64) * 1e-9
+    }
+
+    #[inline]
+    pub fn atime(&self) -> f64 {
+        let duration = self
+            .st_atime
+            .unwrap_or(UNIX_EPOCH)
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_err| Duration::new(0, 0));
+        (duration.as_secs() as f64) + (duration.subsec_nanos() as f64) * 1e-9
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}

--- a/android-collector-rs/src/helper/filter.rs
+++ b/android-collector-rs/src/helper/filter.rs
@@ -1,0 +1,207 @@
+use glob_sl::{MatchOptions, Pattern};
+use std::fs::Metadata;
+use std::io::{Error, ErrorKind};
+
+use crate::helper::options::Options;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Filter {
+    pub dir_include: Vec<Pattern>,
+    pub dir_exclude: Vec<Pattern>,
+    pub file_include: Vec<Pattern>,
+    pub file_exclude: Vec<Pattern>,
+    pub options: Option<MatchOptions>,
+}
+
+pub fn create_filter(options: &Options) -> Result<Option<Filter>, Error> {
+    let mut filter = Filter {
+        dir_include: Vec::new(),
+        dir_exclude: Vec::new(),
+        file_include: Vec::new(),
+        file_exclude: Vec::new(),
+        options: match options.case_sensitive {
+            true => None,
+            false => Some(MatchOptions {
+                case_sensitive: false,
+                ..MatchOptions::new()
+            }),
+        },
+    };
+    if let Some(ref f) = options.dir_include {
+        let f = &mut f
+            .iter()
+            .map(|s| Pattern::new(s))
+            .collect::<Result<Vec<_>, glob_sl::PatternError>>();
+        let f = match f {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("dir_include: {}", e),
+                ));
+            }
+        };
+        filter.dir_include.append(f);
+    }
+    if let Some(ref f) = options.dir_exclude {
+        let f = &mut f
+            .iter()
+            .map(|s| Pattern::new(s))
+            .collect::<Result<Vec<_>, glob_sl::PatternError>>();
+        let f = match f {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("dir_exclude: {}", e),
+                ));
+            }
+        };
+        filter.dir_exclude.append(f);
+    }
+    if let Some(ref f) = options.file_include {
+        let f = &mut f
+            .iter()
+            .map(|s| Pattern::new(s))
+            .collect::<Result<Vec<_>, glob_sl::PatternError>>();
+        let f = match f {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("file_include: {}", e),
+                ));
+            }
+        };
+        filter.file_include.append(f);
+    }
+    if let Some(ref f) = options.file_exclude {
+        let f = &mut f
+            .iter()
+            .map(|s| Pattern::new(s))
+            .collect::<Result<Vec<_>, glob_sl::PatternError>>();
+        let f = match f {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("file_exclude: {}", e),
+                ));
+            }
+        };
+        filter.file_exclude.append(f);
+    }
+    if filter.dir_include.is_empty()
+        && filter.dir_exclude.is_empty()
+        && filter.file_include.is_empty()
+        && filter.file_exclude.is_empty()
+    {
+        return Ok(None);
+    }
+    Ok(Some(filter))
+}
+
+#[inline]
+pub fn filter_direntry(
+    key: &str,
+    filter: &Vec<Pattern>,
+    options: Option<MatchOptions>,
+    empty: bool,
+) -> bool {
+    if filter.is_empty() || key.is_empty() {
+        return empty;
+    }
+    match options {
+        Some(options) => {
+            for f in filter {
+                if f.as_str().ends_with("**") && !key.ends_with('/') {
+                    // Workaround: glob currently has problems with "foo/**"
+                    let mut key = String::from(key);
+                    key.push('/');
+                    if f.matches_with(&key, options) {
+                        return true;
+                    }
+                }
+                if f.matches_with(key, options) {
+                    return true;
+                }
+            }
+        }
+        None => {
+            for f in filter {
+                if f.as_str().ends_with("**") && !key.ends_with('/') {
+                    // Workaround: glob currently has problems with "foo/**"
+                    let mut key = String::from(key);
+                    key.push('/');
+                    if f.matches(&key) {
+                        return true;
+                    }
+                }
+                if f.matches(key) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+#[inline]
+pub fn filter_dir(
+    dir_entry: &jwalk_meta::DirEntry<((), Option<Result<Metadata, Error>>)>,
+    filter_ref: &Filter,
+) -> bool {
+    let mut key = dir_entry.parent_path.to_path_buf();
+    key.push(dir_entry.file_name.clone().into_string().unwrap());
+
+    let key = key.to_str().unwrap();
+
+    /*   let key = key
+    .to_str()
+    .unwrap()
+    .get(root_path_len..)
+    .unwrap_or("")
+    .to_string();*/
+
+    if filter_direntry(&key, &filter_ref.dir_exclude, filter_ref.options, false)
+        || !filter_direntry(&key, &filter_ref.dir_include, filter_ref.options, true)
+    {
+        return false;
+    }
+    true
+}
+
+#[inline]
+pub fn filter_children(
+    children: &mut Vec<
+        Result<jwalk_meta::DirEntry<((), Option<Result<Metadata, Error>>)>, jwalk_meta::Error>,
+    >,
+    filter: &Option<Filter>,
+) {
+    if let Some(filter_ref) = &filter {
+        children.retain(|dir_entry_result| {
+            dir_entry_result
+                .as_ref()
+                .map(|dir_entry| {
+                    if dir_entry.file_type.is_dir() {
+                        return filter_dir(dir_entry, filter_ref);
+                    } else {
+                        let options = filter_ref.options;
+                        let key = match dir_entry.file_name.to_str() {
+                            Some(s) => s,
+                            None => {
+                                return false;
+                            }
+                        };
+                        if filter_direntry(key, &filter_ref.file_exclude, options, false)
+                            || !filter_direntry(key, &filter_ref.file_include, options, true)
+                        {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .unwrap_or(false)
+        });
+    }
+}

--- a/android-collector-rs/src/helper/mod.rs
+++ b/android-collector-rs/src/helper/mod.rs
@@ -1,0 +1,5 @@
+pub mod direntry;
+pub mod filter;
+pub mod options;
+
+pub type ErrorsType = Vec<(String, String)>;

--- a/android-collector-rs/src/helper/options.rs
+++ b/android-collector-rs/src/helper/options.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct Options {
+    pub root_path: PathBuf,
+    pub sorted: bool,
+    pub skip_hidden: bool,
+    pub max_depth: usize,
+    pub max_file_cnt: usize,
+    pub dir_include: Option<Vec<String>>,
+    pub dir_exclude: Option<Vec<String>>,
+    pub file_include: Option<Vec<String>>,
+    pub file_exclude: Option<Vec<String>>,
+    pub case_sensitive: bool,
+    pub follow_links: bool,
+}
+
+impl Options {
+    pub fn new(
+        root_path: PathBuf,
+        sorted: bool,
+        skip_hidden: bool,
+        max_depth: usize,
+        max_file_cnt: usize,
+        dir_include: Option<Vec<String>>,
+        dir_exclude: Option<Vec<String>>,
+        file_include: Option<Vec<String>>,
+        file_exclude: Option<Vec<String>>,
+        case_sensitive: bool,
+        follow_links: bool,
+    ) -> Self {
+        Self {
+            root_path,
+            sorted,
+            skip_hidden,
+            max_depth,
+            max_file_cnt,
+            dir_include,
+            dir_exclude,
+            file_include,
+            file_exclude,
+            case_sensitive,
+            follow_links,
+        }
+    }
+}

--- a/android-collector-rs/src/main.rs
+++ b/android-collector-rs/src/main.rs
@@ -1,0 +1,19 @@
+pub mod cmd;
+pub mod cmd_help;
+pub mod files;
+pub mod helper;
+pub mod process;
+pub mod yara;
+
+fn main() {
+    env_logger::init();
+
+    let args = cmd::cli().get_matches_from(wild::args());
+
+    let _ = match args.subcommand() {
+        Some(("yara", args)) => yara::exec(args),
+        Some(("find", args)) => files::exec_find(args),
+        Some(("ps", args)) => process::exec(args),
+        _ => unreachable!(),
+    };
+}

--- a/android-collector-rs/src/process/mod.rs
+++ b/android-collector-rs/src/process/mod.rs
@@ -1,0 +1,91 @@
+use clap::{ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+
+use log::info;
+
+use crate::cmd;
+use crate::cmd_help;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ProcessInfo {
+    pid: i32,
+    uid: u32,
+    ppid: i32,
+    pgroup: i32,
+    psid: i32,
+    filename: String,
+    priority: i64,
+    state: String,
+    user_time: u64,
+    kernel_time: u64,
+    path: String,
+    context: String,
+    previous_context: String,
+    command_line: Vec<String>,
+    env: Vec<String>,
+    cwd: String,
+}
+
+pub fn process_cmds() -> Command {
+    cmd::command("ps")
+        .about("Get process list information")
+        .long_about(cmd_help::PROCESS_LONG_HELP)
+}
+
+pub fn exec(_args: &ArgMatches) -> anyhow::Result<()> {
+    info!("EXEC PROCESS");
+
+    let mut processes = Vec::new();
+
+    for prc in procfs::process::all_processes().unwrap() {
+        let prc = prc.unwrap();
+        let uid = prc.uid().unwrap();
+        let stat = prc.stat().unwrap();
+
+        let mut env = Vec::new();
+
+        if let Ok(prc_environ) = prc.environ() {
+            for (key, value) in prc_environ.into_iter() {
+                env.push(format!("{:?}={:?}", key, value));
+            }
+        }
+
+        let mut exe = String::new();
+        if let Ok(prc_exe) = prc.exe() {
+            exe = prc_exe.display().to_string()
+        }
+
+        let mut cwd = String::new();
+        if let Ok(prc_cwd) = prc.cwd() {
+            cwd = prc_cwd.display().to_string()
+        }
+
+        let mut command_line = Vec::new();
+        if let Ok(prc_cmdline) = prc.cmdline() {
+            command_line = prc_cmdline.clone();
+        }
+
+        processes.push(ProcessInfo {
+            pid: stat.pid,
+            uid: uid,
+            ppid: stat.ppid,
+            pgroup: stat.pgrp,
+            psid: stat.session,
+            filename: stat.comm.clone(),
+            priority: stat.priority,
+            state: String::from(stat.state),
+            user_time: stat.utime,
+            kernel_time: stat.stime,
+            path: exe,
+            context: "".to_string(),
+            previous_context: "".to_string(),
+            command_line: command_line,
+            env: env.clone(),
+            cwd: cwd,
+        })
+    }
+
+    println!("{:?}", serde_json::to_string(&processes));
+
+    Ok(())
+}

--- a/android-collector-rs/src/process/mod.rs
+++ b/android-collector-rs/src/process/mod.rs
@@ -7,17 +7,17 @@ use crate::cmd;
 use crate::cmd_help;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct ProcessInfo {
-    pid: i32,
+pub struct AndroidQFProcessInfo {
+    pid: u32,
     uid: u32,
-    ppid: i32,
-    pgroup: i32,
-    psid: i32,
+    ppid: u32,
+    pgroup: u32,
+    psid: u32,
     filename: String,
-    priority: i64,
+    priority: u32,
     state: String,
-    user_time: u64,
-    kernel_time: u64,
+    user_time: u32,
+    kernel_time: u32,
     path: String,
     context: String,
     previous_context: String,
@@ -26,14 +26,14 @@ pub struct ProcessInfo {
     cwd: String,
 }
 
-pub fn process_cmds() -> Command {
+pub fn process_ps_cmd() -> Command {
     cmd::command("ps")
         .about("Get process list information")
         .long_about(cmd_help::PROCESS_LONG_HELP)
 }
 
 pub fn exec(_args: &ArgMatches) -> anyhow::Result<()> {
-    info!("EXEC PROCESS");
+    info!("[collector][process][ps]");
 
     let mut processes = Vec::new();
 
@@ -65,27 +65,27 @@ pub fn exec(_args: &ArgMatches) -> anyhow::Result<()> {
             command_line = prc_cmdline.clone();
         }
 
-        processes.push(ProcessInfo {
-            pid: stat.pid,
-            uid: uid,
-            ppid: stat.ppid,
-            pgroup: stat.pgrp,
-            psid: stat.session,
+        processes.push(AndroidQFProcessInfo {
+            pid: stat.pid as u32,
+            uid,
+            ppid: stat.ppid as u32,
+            pgroup: stat.pgrp as u32,
+            psid: stat.session as u32,
             filename: stat.comm.clone(),
-            priority: stat.priority,
+            priority: stat.priority as u32,
             state: String::from(stat.state),
-            user_time: stat.utime,
-            kernel_time: stat.stime,
+            user_time: stat.utime as u32,
+            kernel_time: stat.stime as u32,
             path: exe,
             context: "".to_string(),
             previous_context: "".to_string(),
-            command_line: command_line,
+            command_line,
             env: env.clone(),
-            cwd: cwd,
+            cwd,
         })
     }
 
-    println!("{:?}", serde_json::to_string(&processes));
+    println!("{}", serde_json::to_string(&processes).unwrap());
 
     Ok(())
 }

--- a/android-collector-rs/src/yara/mod.rs
+++ b/android-collector-rs/src/yara/mod.rs
@@ -42,7 +42,9 @@ pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
     .follow_links(false)
     .collect()?;
 
-    println!("{:?}", scan);
+    for file in scan.results {
+        println!("{:?}", file);
+    }
 
     Ok(())
 }

--- a/android-collector-rs/src/yara/mod.rs
+++ b/android-collector-rs/src/yara/mod.rs
@@ -1,0 +1,48 @@
+pub mod scan;
+pub mod scan_result;
+
+use clap::{arg, value_parser, ArgMatches, Command};
+use log::info;
+
+use crate::cmd;
+use crate::cmd_help;
+
+use scan::Scan;
+
+pub fn yara_cmds() -> Command {
+    cmd::command("yara")
+        .about("Scan a file or directory with Yara-x")
+        .long_about(cmd_help::YARA_SCAN_LONG_HELP)
+        .arg(
+            arg!(-p --"path" <PATH>)
+                .help("Scan the specific PATH")
+                .value_parser(value_parser!(String)),
+        )
+        .arg(
+            arg!(-r --"rule_path" <PATH>)
+                .help("Use a specific rule PATH")
+                .value_parser(value_parser!(String)),
+        )
+}
+
+pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
+    info!("EXEC SCAN");
+
+    let scan = Scan::new(
+        args.get_one::<String>("path").unwrap(),
+        args.get_one::<String>("rule_path").unwrap(),
+        None,
+    )?
+    .dir_exclude(Some(vec![
+        "/proc/**".to_string(),
+        "/sys/**".to_string(),
+        "/system/**".to_string(),
+    ]))
+    .max_depth(5)
+    .follow_links(false)
+    .collect()?;
+
+    println!("{:?}", scan);
+
+    Ok(())
+}

--- a/android-collector-rs/src/yara/mod.rs
+++ b/android-collector-rs/src/yara/mod.rs
@@ -9,7 +9,7 @@ use crate::cmd_help;
 
 use scan::Scan;
 
-pub fn yara_cmds() -> Command {
+pub fn yara_cmd() -> Command {
     cmd::command("yara")
         .about("Scan a file or directory with Yara-x")
         .long_about(cmd_help::YARA_SCAN_LONG_HELP)
@@ -26,7 +26,7 @@ pub fn yara_cmds() -> Command {
 }
 
 pub fn exec(args: &ArgMatches) -> anyhow::Result<()> {
-    info!("EXEC SCAN");
+    info!("[collector][yara]");
 
     let scan = Scan::new(
         args.get_one::<String>("path").unwrap(),

--- a/android-collector-rs/src/yara/scan.rs
+++ b/android-collector-rs/src/yara/scan.rs
@@ -1,0 +1,491 @@
+use jwalk_meta::WalkDirGeneric;
+use std::fs;
+
+use flume::{unbounded, Receiver, Sender};
+use std::fs::canonicalize;
+use std::fs::Metadata;
+use std::io::Error;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Instant;
+
+use crate::helper::filter::{create_filter, filter_children, Filter};
+use crate::helper::options::Options;
+use crate::helper::ErrorsType;
+use crate::yara::scan_result::{PatternJson, RuleJson, ScanResult, ScanResults, YaraEntry};
+
+use yara_x::errors::ScanError;
+use yara_x::{Patterns, Rule, Rules, Scanner};
+
+fn rules_to_json(scan_results: &mut dyn ExactSizeIterator<Item = Rule>) -> Vec<RuleJson> {
+    scan_results
+        .map(move |rule| RuleJson {
+            identifier: rule.identifier().to_string(),
+            namespace: Some(rule.namespace().to_string()),
+            meta: Some(rule.metadata().into_json()),
+            tags: Some(
+                rule.tags()
+                    .map(|t| t.identifier().to_string())
+                    .collect::<Vec<_>>(),
+            ),
+            strings: Some(patterns_to_json(rule.patterns(), 1024)),
+        })
+        .collect()
+}
+
+fn patterns_to_json(patterns: Patterns<'_, '_>, string_limit: usize) -> Vec<PatternJson> {
+    patterns
+        .flat_map(|pattern| {
+            let identifier = pattern.identifier();
+
+            pattern.matches().map(|pattern_match| {
+                let match_range = pattern_match.range();
+                let match_data = pattern_match.data();
+
+                let more_bytes_message = match match_data.len().saturating_sub(string_limit) {
+                    0 => None,
+                    n => Some(format!(" ... {} more bytes", n)),
+                };
+
+                let string = match_data
+                    .iter()
+                    .take(string_limit)
+                    .flat_map(|char| char.escape_ascii())
+                    .map(|c| c as char)
+                    .chain(more_bytes_message.iter().flat_map(|msg| msg.chars()))
+                    .collect::<String>();
+
+                PatternJson {
+                    identifier: identifier.to_owned(),
+                    offset: match_range.start,
+                    r#match: string,
+                    xor_key: pattern_match.xor_key(),
+                    plaintext: pattern_match.xor_key().map(|xor_key| {
+                        match_data
+                            .iter()
+                            .take(string_limit)
+                            .map(|char| char ^ xor_key)
+                            .flat_map(|char| char.escape_ascii())
+                            .map(|char| char as char)
+                            .collect()
+                    }),
+                }
+            })
+        })
+        .collect()
+}
+
+pub fn get_root_path_len(root_path: &Path) -> usize {
+    let root_path = root_path.to_str().unwrap();
+    let mut root_path_len = root_path.len();
+    if !root_path.ends_with('/') {
+        root_path_len += 1;
+    }
+    root_path_len
+}
+
+#[inline]
+fn create_entry(
+    rules: Arc<Mutex<Rules>>,
+    dir_entry: &jwalk_meta::DirEntry<((), Option<Result<Metadata, Error>>)>,
+) -> ScanResult {
+    let file_type = dir_entry.file_type;
+
+    let mut matched_count = 0;
+    let mut rules_result = Vec::new();
+
+    let path = String::from(dir_entry.path().to_str().unwrap());
+
+    if file_type.is_file() {
+        let rules = rules.lock().unwrap();
+
+        let mut scanner = Scanner::new(&rules);
+
+        let _ = match scanner.scan_file(path.clone()) {
+            Err(_) => {}
+            Ok(scan_result) => {
+                let mut wanted_rules = scan_result.matching_rules();
+                let rules = rules_to_json(&mut wanted_rules);
+                matched_count = wanted_rules.len();
+
+                rules_result = rules.clone();
+            }
+        };
+    }
+
+    let entry: ScanResult = ScanResult::YaraEntry(YaraEntry {
+        path: path,
+        count: matched_count,
+        rules: rules_result,
+    });
+    entry
+}
+
+fn entries_thread(
+    options: Options,
+    rule_path: String,
+    filter: Option<Filter>,
+    tx: Sender<ScanResult>,
+    stop: Arc<AtomicBool>,
+) {
+    let file_yara = fs::File::open(rule_path.clone()).unwrap();
+
+    let rules = Rules::deserialize_from(file_yara).unwrap();
+
+    let root_path_len = get_root_path_len(&options.root_path);
+
+    let dir_entry: jwalk_meta::DirEntry<((), Option<Result<Metadata, Error>>)> =
+        jwalk_meta::DirEntry::from_path(
+            0,
+            &options.root_path,
+            true,
+            true,
+            options.follow_links,
+            Arc::new(Vec::new()),
+        )
+        .unwrap();
+
+    let rules_m = Arc::new(Mutex::new(rules));
+
+    if !dir_entry.file_type.is_dir() {
+        let _ = tx.send(create_entry(rules_m.clone(), &dir_entry));
+        return;
+    }
+
+    let max_file_cnt = options.max_file_cnt;
+    let mut file_cnt = 0;
+
+    for result in WalkDirGeneric::new(&options.root_path)
+        .skip_hidden(options.skip_hidden)
+        .follow_links(options.follow_links)
+        .sort(options.sorted)
+        .max_depth(options.max_depth)
+        .read_metadata(true)
+        .process_read_dir(move |_, root_dir, _, children| {
+            if let Some(root_dir) = root_dir.to_str() {
+                if root_dir.len() + 1 < root_path_len {
+                    return;
+                }
+            } else {
+                return;
+            }
+            filter_children(children, &filter);
+            children.iter_mut().for_each(|dir_entry_result| {
+                if let Ok(dir_entry) = dir_entry_result {
+                    if tx.send(create_entry(rules_m.clone(), dir_entry)).is_err() {
+                        return;
+                    }
+                }
+            });
+        })
+    {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        if let Ok(dir_entry) = result {
+            if !dir_entry.file_type.is_dir() {
+                file_cnt += 1;
+                if max_file_cnt > 0 && file_cnt > max_file_cnt {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Scan {
+    // Options
+    options: Options,
+    rule_path: String,
+    store: bool,
+    // Results
+    entries: ScanResults,
+    duration: Arc<Mutex<f64>>,
+    finished: Arc<AtomicBool>,
+    // Internal
+    thr: Option<thread::JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
+    rx: Option<Receiver<ScanResult>>,
+}
+
+impl Scan {
+    pub fn new<P: AsRef<Path>>(
+        root_path: P,
+        rule_path: P,
+        store: Option<bool>,
+    ) -> Result<Self, Error> {
+        let rule_path_str = String::from(rule_path.as_ref().to_str().unwrap());
+
+        Ok(Scan {
+            options: Options {
+                root_path: canonicalize(root_path.as_ref().to_str().unwrap())?,
+                sorted: false,
+                skip_hidden: false,
+                max_depth: usize::MAX,
+                max_file_cnt: usize::MAX,
+                dir_include: None,
+                dir_exclude: None,
+                file_include: None,
+                file_exclude: None,
+                case_sensitive: false,
+                follow_links: false,
+            },
+            rule_path: rule_path_str.clone(),
+            store: store.unwrap_or(true),
+            entries: ScanResults::new(),
+            duration: Arc::new(Mutex::new(0.0)),
+            finished: Arc::new(AtomicBool::new(false)),
+            thr: None,
+            stop: Arc::new(AtomicBool::new(false)),
+            rx: None,
+        })
+    }
+
+    /// Return results in sorted order.
+    pub fn sorted(mut self, sorted: bool) -> Self {
+        self.options.sorted = sorted;
+        self
+    }
+
+    /// Skip hidden entries. Enabled by default.
+    pub fn skip_hidden(mut self, skip_hidden: bool) -> Self {
+        self.options.skip_hidden = skip_hidden;
+        self
+    }
+
+    /// Set the maximum depth of entries yield by the iterator.
+    ///
+    /// The smallest depth is `0` and always corresponds to the path given
+    /// to the `new` function on this type. Its direct descendents have depth
+    /// `1`, and their descendents have depth `2`, and so on.
+    ///
+    /// Note that this will not simply filter the entries of the iterator, but
+    /// it will actually avoid descending into directories when the depth is
+    /// exceeded.
+    pub fn max_depth(mut self, depth: usize) -> Self {
+        self.options.max_depth = match depth {
+            0 => usize::MAX,
+            _ => depth,
+        };
+        self
+    }
+
+    /// Set maximum number of files to collect
+    pub fn max_file_cnt(mut self, max_file_cnt: usize) -> Self {
+        self.options.max_file_cnt = match max_file_cnt {
+            0 => usize::MAX,
+            _ => max_file_cnt,
+        };
+        self
+    }
+
+    /// Set directory include filter
+    pub fn dir_include(mut self, dir_include: Option<Vec<String>>) -> Self {
+        self.options.dir_include = dir_include;
+        self
+    }
+
+    /// Set directory exclude filter
+    pub fn dir_exclude(mut self, dir_exclude: Option<Vec<String>>) -> Self {
+        self.options.dir_exclude = dir_exclude;
+        self
+    }
+
+    /// Set file include filter
+    pub fn file_include(mut self, file_include: Option<Vec<String>>) -> Self {
+        self.options.file_include = file_include;
+        self
+    }
+
+    /// Set file exclude filter
+    pub fn file_exclude(mut self, file_exclude: Option<Vec<String>>) -> Self {
+        self.options.file_exclude = file_exclude;
+        self
+    }
+
+    /// Set case sensitive filename filtering
+    pub fn case_sensitive(mut self, case_sensitive: bool) -> Self {
+        self.options.case_sensitive = case_sensitive;
+        self
+    }
+
+    /// Set follow symlinks
+    pub fn follow_links(mut self, follow_links: bool) -> Self {
+        self.options.follow_links = follow_links;
+        self
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        *self.duration.lock().unwrap() = 0.0;
+    }
+
+    pub fn start(&mut self) -> Result<(), Error> {
+        if self.busy() {
+            return Err(Error::other("Busy"));
+        }
+
+        self.clear();
+        let options = self.options.clone();
+        let filter = create_filter(&options)?;
+        let (tx, rx) = unbounded();
+        self.rx = Some(rx);
+        self.stop.store(false, Ordering::Relaxed);
+        let stop = self.stop.clone();
+        let duration = self.duration.clone();
+        let finished = self.finished.clone();
+
+        let rule_path = self.rule_path.clone();
+
+        self.thr = Some(thread::spawn(move || {
+            let start_time = Instant::now();
+            entries_thread(options, rule_path, filter, tx, stop);
+            *duration.lock().unwrap() = start_time.elapsed().as_secs_f64();
+            finished.store(true, Ordering::Relaxed);
+        }));
+        Ok(())
+    }
+
+    pub fn join(&mut self) -> bool {
+        if let Some(thr) = self.thr.take() {
+            if let Err(_e) = thr.join() {
+                return false;
+            }
+            return true;
+        }
+        false
+    }
+
+    pub fn stop(&mut self) -> bool {
+        if let Some(thr) = self.thr.take() {
+            self.stop.store(true, Ordering::Relaxed);
+            if let Err(_e) = thr.join() {
+                return false;
+            }
+            return true;
+        }
+        false
+    }
+
+    pub fn collect(&mut self) -> Result<ScanResults, Error> {
+        if !self.finished() {
+            if !self.busy() {
+                self.start()?;
+            }
+            self.join();
+        }
+        Ok(self.results(true))
+    }
+
+    pub fn has_results(&mut self, only_new: bool) -> bool {
+        if let Some(ref rx) = self.rx {
+            if !rx.is_empty() {
+                return true;
+            }
+        }
+        if only_new {
+            return false;
+        }
+        !self.entries.is_empty()
+    }
+
+    pub fn results_cnt(&mut self, only_new: bool) -> usize {
+        if let Some(ref rx) = self.rx {
+            if only_new {
+                rx.len()
+            } else {
+                self.entries.len() + rx.len()
+            }
+        } else if only_new {
+            0
+        } else {
+            self.entries.len()
+        }
+    }
+
+    pub fn results(&mut self, only_new: bool) -> ScanResults {
+        let mut results = ScanResults::new();
+        if let Some(ref rx) = self.rx {
+            while let Ok(entry) = rx.try_recv() {
+                if let ScanResult::Error(e) = entry {
+                    results.errors.push(e);
+                } else {
+                    results.results.push(entry);
+                }
+            }
+        }
+        if self.store {
+            self.entries.extend(&results);
+        }
+        if !only_new && self.store {
+            return self.entries.clone();
+        }
+        results
+    }
+
+    pub fn has_entries(&mut self, only_new: bool) -> bool {
+        if let Some(ref rx) = self.rx {
+            if !rx.is_empty() {
+                return true;
+            }
+        }
+        if only_new {
+            return false;
+        }
+        !self.entries.is_empty()
+    }
+
+    pub fn entries_cnt(&mut self, only_new: bool) -> usize {
+        if let Some(ref rx) = self.rx {
+            if only_new {
+                return rx.len();
+            }
+            self.entries.len() + rx.len()
+        } else {
+            self.entries.len()
+        }
+    }
+
+    pub fn entries(&mut self, only_new: bool) -> Vec<ScanResult> {
+        self.results(only_new).results
+    }
+
+    pub fn has_errors(&mut self) -> bool {
+        !self.entries.errors.is_empty()
+    }
+
+    pub fn errors_cnt(&mut self) -> usize {
+        self.entries.errors.len()
+    }
+
+    pub fn errors(&mut self, only_new: bool) -> ErrorsType {
+        self.results(only_new).errors
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        self.entries.to_json()
+    }
+
+    pub fn duration(&mut self) -> f64 {
+        *self.duration.lock().unwrap()
+    }
+
+    pub fn finished(&mut self) -> bool {
+        self.finished.load(Ordering::Relaxed)
+    }
+
+    pub fn busy(&self) -> bool {
+        if let Some(ref thr) = self.thr {
+            !thr.is_finished()
+        } else {
+            false
+        }
+    }
+
+    pub fn options(&self) -> Options {
+        self.options.clone()
+    }
+}

--- a/android-collector-rs/src/yara/scan.rs
+++ b/android-collector-rs/src/yara/scan.rs
@@ -5,19 +5,18 @@ use flume::{unbounded, Receiver, Sender};
 use std::fs::canonicalize;
 use std::fs::Metadata;
 use std::io::Error;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Instant;
 
+use yara_x::{Patterns, Rule, Rules, Scanner};
+
 use crate::helper::filter::{create_filter, filter_children, Filter};
 use crate::helper::options::Options;
 use crate::helper::ErrorsType;
 use crate::yara::scan_result::{PatternJson, RuleJson, ScanResult, ScanResults, YaraEntry};
-
-use yara_x::errors::ScanError;
-use yara_x::{Patterns, Rule, Rules, Scanner};
 
 fn rules_to_json(scan_results: &mut dyn ExactSizeIterator<Item = Rule>) -> Vec<RuleJson> {
     scan_results
@@ -116,7 +115,7 @@ fn create_entry(
     }
 
     let entry: ScanResult = ScanResult::YaraEntry(YaraEntry {
-        path: path,
+        path,
         count: matched_count,
         rules: rules_result,
     });

--- a/android-collector-rs/src/yara/scan_result.rs
+++ b/android-collector-rs/src/yara/scan_result.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+
+use crate::helper::ErrorsType;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct PatternJson {
+    pub identifier: String,
+    pub offset: usize,
+    pub r#match: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub xor_key: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plaintext: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct RuleJson {
+    pub identifier: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strings: Option<Vec<PatternJson>>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct YaraEntry {
+    pub path: String,
+    pub count: usize,
+    pub rules: Vec<RuleJson>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ScanResult {
+    YaraEntry(YaraEntry),
+    Error((String, String)),
+}
+
+impl ScanResult {
+    #[inline]
+    pub fn path(&self) -> &String {
+        match self {
+            Self::YaraEntry(e) => &e.path,
+            Self::Error(e) => &e.0,
+        }
+    }
+
+    #[inline]
+    pub fn error(&self) -> Option<&(String, String)> {
+        match self {
+            Self::Error(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ScanResults {
+    pub results: Vec<ScanResult>,
+    pub errors: ErrorsType,
+}
+
+impl ScanResults {
+    pub fn new() -> Self {
+        ScanResults {
+            results: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.results.clear();
+        self.errors.clear();
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty() && self.errors.is_empty()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.results.len() + self.errors.len()
+    }
+
+    pub fn extend(&mut self, results: &ScanResults) {
+        self.results.extend_from_slice(&results.results);
+        self.errors.extend_from_slice(&results.errors);
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}
+
+impl Default for ScanResults {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -14,7 +14,7 @@ import (
 	saveRuntime "github.com/botherder/go-savetime/runtime"
 )
 
-//go:embed collector_*
+//go:embed collector_* rules.yarc
 var Collector embed.FS
 
 type Asset struct {

--- a/modules/files.go
+++ b/modules/files.go
@@ -63,6 +63,8 @@ func (f *Files) Run(acq *acquisition.Acquisition, fast bool) error {
 	}
 
 	for _, folder := range folders {
+		log.Debugf("Starting to collect files in '%s'.", folder)
+
 		var out []adb.FileInfo
 		var err error
 		if method == "collector" {

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -35,6 +35,7 @@ func List() []Module {
 		NewLogcat(),
 		NewLogs(),
 		NewTemp(),
+		NewYara(),
 	}
 }
 

--- a/modules/yara.go
+++ b/modules/yara.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Anthony Desnos
+// Use of this source code is governed by the MVT License 1.1
+// which can be found in the LICENSE file.
+
+package modules
+
+import (
+	"path/filepath"
+
+	"github.com/botherder/go-savetime/slice"
+	"github.com/mvt-project/androidqf/acquisition"
+	"github.com/mvt-project/androidqf/adb"
+	"github.com/mvt-project/androidqf/log"
+)
+
+type Yara struct {
+	StoragePath string
+}
+
+func NewYara() *Yara {
+	return &Yara{}
+}
+
+func (y *Yara) Name() string {
+	return "yara"
+}
+
+func (y *Yara) InitStorage(storagePath string) error {
+	y.StoragePath = storagePath
+	return nil
+}
+
+func (y *Yara) Run(acq *acquisition.Acquisition, fast bool) error {
+	log.Info("Collecting results of Yara...")
+	var fileFounds []string
+	var fileDetails []adb.FileInfo
+
+	log.Debug("Using collector to check Yara rules")
+
+	folders := []string{
+		"/sdcard/", "/system/", "/system_ext/", "/vendor/",
+		"/cust/", "/product/", "/apex/", "/data/local/tmp/", "/data/media/0/",
+		"/data/misc/radio/", "/data/vendor/secradio/", "/data/log/", "/tmp/", "/", "/data/data/",
+	}
+	// If tmp folder different from standard tmp, add it to the list
+	if acq.TmpDir != "/data/local/tmp/" {
+		folders = append(folders, acq.TmpDir)
+	}
+	if acq.SdCard != "/sdcard/" {
+		folders = append(folders, acq.SdCard)
+	}
+
+	for _, folder := range folders {
+		log.Debugf("Starting to collect files in '%s'.", folder)
+
+		var out []adb.FileInfo
+		var err error
+
+		out, err = acq.Collector.Yara(folder)
+
+		if err == nil {
+			for _, s := range out {
+				if !slice.Contains(fileFounds, s.Path) {
+					fileFounds = append(fileFounds, s.Path)
+					fileDetails = append(fileDetails, s)
+				}
+			}
+		}
+	}
+
+	return saveCommandOutputJson(filepath.Join(y.StoragePath, "yara.json"), &fileDetails)
+}


### PR DESCRIPTION
This PR contains multiples modifications of the original Go collector, and keep compatibility with the current Go modules (json output format is the same, so it should not break anything):
- files information support
- processes information support
- yara-x integration

The Yara support is not yet supported in the Go binary, but it can be launched manually right now (I will send another PR with proper integration)
