### PR TITLE
Disable UPX for Mac universal binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -106,6 +106,7 @@ upx:
   - # Compress binaries to make them smaller
     enabled: true
     compress: best
+    goos: [linux, windows]  # Mac universal binaries broken with UPX
 
 
 # Archives disabled - we only want raw binaries


### PR DESCRIPTION
UPX compression seems to break the universal binary format for Mac. This PR disables UPX for these builds. 