### PR TITLE
use system adb/collector when available, extract bundled assets to temp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ These commands will generate binaries in a *build/* folder.
 
 ### Building for distribution packages without bundled assets
 
-Distribution packages can opt out of embedding the bundled ADB and collector
-binaries by building with the `unbundle` build tag:
+Default builds always use the bundled ADB binary. Distribution packages can opt
+out of embedding the bundled ADB and collector binaries by building with the
+`unbundle` build tag:
 
 ```bash
 go build -tags unbundle -o build/
@@ -59,10 +60,17 @@ go build -tags unbundle -o build/
 
 When this tag is enabled, androidqf expects:
 
-- `adb` to be available from the system `PATH`.
+- `adb` to be available from the system `PATH` with Android SDK Platform-Tools
+  `36.0.2` or newer.
 - collector binaries to be installed under
   `/usr/lib/androidqf/android-collector/` using the names expected by
   androidqf, such as `collector_arm` and `collector_arm64`.
+
+Packagers can run the same ADB version check with:
+
+```bash
+go test -tags unbundle ./adb
+```
 
 Packagers may remove the bundled binary assets from `assets/` before building,
 but the `assets/` package directory and its Go source files must remain present.

--- a/acquisition/acquisition.go
+++ b/acquisition/acquisition.go
@@ -29,6 +29,7 @@ type Acquisition struct {
 	UUID             string              `json:"uuid"`
 	AndroidQFVersion string              `json:"androidqf_version"`
 	StoragePath      string              `json:"storage_path"`
+	BaseDir          string              `json:"base_dir"`
 	Started          time.Time           `json:"started"`
 	Completed        time.Time           `json:"completed"`
 	Collector        *adb.Collector      `json:"collector"`
@@ -55,6 +56,7 @@ func New(path string) (*Acquisition, error) {
 	} else {
 		acq.StoragePath = path
 	}
+	acq.BaseDir = filepath.Dir(acq.StoragePath)
 	// Check if the path exist
 	stat, err := os.Stat(acq.StoragePath)
 	if os.IsNotExist(err) {
@@ -82,7 +84,7 @@ func New(path string) (*Acquisition, error) {
 	acq.Collector = coll
 
 	// Try to initialize encrypted streaming mode
-	encWriter, err := NewEncryptedZipWriter(acq.UUID)
+	encWriter, err := NewEncryptedZipWriter(acq.UUID, acq.BaseDir)
 	if err != nil {
 		// No key file or encryption setup failed, use normal mode
 		log.Debug("Encrypted streaming not available, using normal mode")

--- a/acquisition/acquisition.go
+++ b/acquisition/acquisition.go
@@ -20,7 +20,6 @@ import (
 	rt "github.com/botherder/go-savetime/runtime"
 	"github.com/google/uuid"
 	"github.com/mvt-project/androidqf/adb"
-	"github.com/mvt-project/androidqf/assets"
 	"github.com/mvt-project/androidqf/log"
 	"github.com/mvt-project/androidqf/utils"
 )
@@ -175,9 +174,9 @@ func (a *Acquisition) Complete() {
 		a.Collector.Clean()
 	}
 
-	// Stop ADB server before trying to remove extracted assets
+	// Stop ADB server, then clean up any temp directory used for bundled assets.
 	adb.Client.KillServer()
-	assets.CleanAssets()
+	adb.Client.Cleanup()
 }
 
 func (a *Acquisition) GetSystemInformation() error {

--- a/acquisition/encrypted_stream.go
+++ b/acquisition/encrypted_stream.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"filippo.io/age"
-	saveRuntime "github.com/botherder/go-savetime/runtime"
 	"github.com/mvt-project/androidqf/log"
 )
 
@@ -30,9 +29,8 @@ type EncryptedZipWriter struct {
 }
 
 // NewEncryptedZipWriter creates a new encrypted zip writer if key.txt exists
-func NewEncryptedZipWriter(uuid string) (*EncryptedZipWriter, error) {
-	cwd := saveRuntime.GetExecutableDirectory()
-	keyFilePath := filepath.Join(cwd, "key.txt")
+func NewEncryptedZipWriter(uuid, baseDir string) (*EncryptedZipWriter, error) {
+	keyFilePath := filepath.Join(baseDir, "key.txt")
 
 	// Check if key file exists
 	if _, err := os.Stat(keyFilePath); os.IsNotExist(err) {
@@ -55,7 +53,7 @@ func NewEncryptedZipWriter(uuid string) (*EncryptedZipWriter, error) {
 
 	// Create output file
 	encFileName := fmt.Sprintf("%s.zip.age", uuid)
-	outputPath := filepath.Join(cwd, encFileName)
+	outputPath := filepath.Join(baseDir, encFileName)
 
 	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {

--- a/acquisition/secure.go
+++ b/acquisition/secure.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"filippo.io/age"
-	saveRuntime "github.com/botherder/go-savetime/runtime"
 	"github.com/mvt-project/androidqf/log"
 )
 
@@ -44,9 +43,7 @@ func (a *Acquisition) StoreSecurely() error {
 		return nil
 	}
 
-	cwd := saveRuntime.GetExecutableDirectory()
-
-	keyFilePath := filepath.Join(cwd, "key.txt")
+	keyFilePath := filepath.Join(a.BaseDir, "key.txt")
 	if _, err := os.Stat(keyFilePath); os.IsNotExist(err) {
 		return nil
 	}
@@ -54,7 +51,7 @@ func (a *Acquisition) StoreSecurely() error {
 	log.Info("You provided an age public key, storing the acquisition securely.")
 
 	zipFileName := fmt.Sprintf("%s.zip", a.UUID)
-	zipFilePath := filepath.Join(cwd, zipFileName)
+	zipFilePath := filepath.Join(a.BaseDir, zipFileName)
 
 	log.Info("Compressing the acquisition folder. This might take a while...")
 
@@ -83,7 +80,7 @@ func (a *Acquisition) StoreSecurely() error {
 	defer zipFile.Close()
 
 	encFileName := fmt.Sprintf("%s.age", zipFileName)
-	encFilePath := filepath.Join(cwd, encFileName)
+	encFilePath := filepath.Join(a.BaseDir, encFileName)
 	encFile, err := os.OpenFile(encFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("unable to create encrypted file: %v", err)

--- a/adb/adb.go
+++ b/adb/adb.go
@@ -8,6 +8,7 @@ package adb
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -16,8 +17,18 @@ import (
 )
 
 type ADB struct {
-	ExePath string
-	Serial  string
+	ExePath      string
+	Serial       string
+	TmpAssetsDir string
+}
+
+// Cleanup removes the temporary directory used to store extracted adb assets,
+// if one was created. It is a no-op when the system adb was used instead.
+func (a *ADB) Cleanup() {
+	if a.TmpAssetsDir != "" {
+		os.RemoveAll(a.TmpAssetsDir)
+		a.TmpAssetsDir = ""
+	}
 }
 
 var Client *ADB

--- a/adb/adb_darwin.go
+++ b/adb/adb_darwin.go
@@ -6,25 +6,35 @@
 package adb
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
-	saveRuntime "github.com/botherder/go-savetime/runtime"
 	"github.com/mvt-project/androidqf/assets"
 )
 
 func (a *ADB) findExe() error {
-	err := assets.DeployAssets()
-	if err != nil {
-		return err
+	// Prefer a system-installed adb (covers distro packages where adb is on PATH).
+	if path, err := exec.LookPath("adb"); err == nil {
+		a.ExePath = path
+		return nil
 	}
 
-	adbPath, err := exec.LookPath("adb")
-	if err == nil {
-		a.ExePath = adbPath
-		return nil
-	} else {
-		a.ExePath = filepath.Join(saveRuntime.GetExecutableDirectory(), "adb")
+	// Fall back to the bundled binary. Extract it into a temp directory so we
+	// never try to write next to the executable (which may be /usr/bin or
+	// another read-only system path).
+	tmpDir, err := os.MkdirTemp("", "androidqf-adb-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir for adb: %v", err)
 	}
+
+	if err := assets.DeployAssetsToDir(tmpDir); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to deploy bundled adb: %v", err)
+	}
+
+	a.ExePath = filepath.Join(tmpDir, "adb")
+	a.TmpAssetsDir = tmpDir
 	return nil
 }

--- a/adb/adb_darwin.go
+++ b/adb/adb_darwin.go
@@ -1,3 +1,5 @@
+//go:build !unbundle
+
 // androidqf - Android Quick Forensics
 // Copyright (c) 2021-2022 Claudio Guarnieri.
 // Use of this software is governed by the MVT License 1.1 that can be found at
@@ -8,20 +10,13 @@ package adb
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/mvt-project/androidqf/assets"
 )
 
 func (a *ADB) findExe() error {
-	// Prefer a system-installed adb (covers distro packages where adb is on PATH).
-	if path, err := exec.LookPath("adb"); err == nil {
-		a.ExePath = path
-		return nil
-	}
-
-	// Fall back to the bundled binary. Extract it into a temp directory so we
+	// Extract the bundled binary into a temp directory so we
 	// never try to write next to the executable (which may be /usr/bin or
 	// another read-only system path).
 	tmpDir, err := os.MkdirTemp("", "androidqf-adb-*")
@@ -35,6 +30,10 @@ func (a *ADB) findExe() error {
 	}
 
 	a.ExePath = filepath.Join(tmpDir, "adb")
+	if err := validatePlatformToolsVersion(a.ExePath); err != nil {
+		os.RemoveAll(tmpDir)
+		return err
+	}
 	a.TmpAssetsDir = tmpDir
 	return nil
 }

--- a/adb/adb_linux.go
+++ b/adb/adb_linux.go
@@ -6,24 +6,35 @@
 package adb
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
-	saveRuntime "github.com/botherder/go-savetime/runtime"
 	"github.com/mvt-project/androidqf/assets"
 )
 
 func (a *ADB) findExe() error {
-	err := assets.DeployAssets()
-	if err != nil {
-		return err
+	// Prefer a system-installed adb (covers distro packages where adb is on PATH).
+	if path, err := exec.LookPath("adb"); err == nil {
+		a.ExePath = path
+		return nil
 	}
 
-	adbPath, err := exec.LookPath("adb")
-	if err == nil {
-		a.ExePath = adbPath
-	} else {
-		a.ExePath = filepath.Join(saveRuntime.GetExecutableDirectory(), "adb")
+	// Fall back to the bundled binary. Extract it into a temp directory so we
+	// never try to write next to the executable (which may be /usr/bin or
+	// another read-only system path).
+	tmpDir, err := os.MkdirTemp("", "androidqf-adb-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir for adb: %v", err)
 	}
+
+	if err := assets.DeployAssetsToDir(tmpDir); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to deploy bundled adb: %v", err)
+	}
+
+	a.ExePath = filepath.Join(tmpDir, "adb")
+	a.TmpAssetsDir = tmpDir
 	return nil
 }

--- a/adb/adb_linux.go
+++ b/adb/adb_linux.go
@@ -1,3 +1,5 @@
+//go:build !unbundle
+
 // androidqf - Android Quick Forensics
 // Copyright (c) 2021-2022 Claudio Guarnieri.
 // Use of this software is governed by the MVT License 1.1 that can be found at
@@ -8,20 +10,13 @@ package adb
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/mvt-project/androidqf/assets"
 )
 
 func (a *ADB) findExe() error {
-	// Prefer a system-installed adb (covers distro packages where adb is on PATH).
-	if path, err := exec.LookPath("adb"); err == nil {
-		a.ExePath = path
-		return nil
-	}
-
-	// Fall back to the bundled binary. Extract it into a temp directory so we
+	// Extract the bundled binary into a temp directory so we
 	// never try to write next to the executable (which may be /usr/bin or
 	// another read-only system path).
 	tmpDir, err := os.MkdirTemp("", "androidqf-adb-*")
@@ -35,6 +30,10 @@ func (a *ADB) findExe() error {
 	}
 
 	a.ExePath = filepath.Join(tmpDir, "adb")
+	if err := validatePlatformToolsVersion(a.ExePath); err != nil {
+		os.RemoveAll(tmpDir)
+		return err
+	}
 	a.TmpAssetsDir = tmpDir
 	return nil
 }

--- a/adb/adb_unbundle.go
+++ b/adb/adb_unbundle.go
@@ -1,0 +1,35 @@
+//go:build unbundle
+
+// androidqf - Android Quick Forensics
+// Copyright (c) 2021-2022 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+package adb
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func (a *ADB) findExe() error {
+	path, err := exec.LookPath(systemADBName())
+	if err != nil {
+		return fmt.Errorf("unbundle builds require a package-maintained %s on PATH: %v", systemADBName(), err)
+	}
+
+	if err := validatePlatformToolsVersion(path); err != nil {
+		return err
+	}
+
+	a.ExePath = path
+	return nil
+}
+
+func systemADBName() string {
+	if runtime.GOOS == "windows" {
+		return "adb.exe"
+	}
+	return "adb"
+}

--- a/adb/adb_windows.go
+++ b/adb/adb_windows.go
@@ -7,6 +7,7 @@ package adb
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,28 +17,34 @@ import (
 )
 
 func (a *ADB) findExe() error {
-	// TODO: only deploy assets when needed
-	err := assets.DeployAssets()
-	if err != nil {
-		return err
+	// Prefer a system-installed adb (covers distro packages where adb is on PATH).
+	if path, err := exec.LookPath("adb.exe"); err == nil {
+		a.ExePath = path
+		return nil
 	}
 
-	adbPath, err := exec.LookPath("adb.exe")
-	if err == nil {
-		a.ExePath = adbPath
-	} else {
-		// Get path of the current directory
-		ex, err := os.Executable()
-		if err != nil {
-			return err
-		}
-		// Need full path to bypass go 1.19 restrictions about local path
-		a.ExePath = filepath.Join(filepath.Dir(ex), "adb.exe")
-		_, err = os.Stat(a.ExePath)
-		if err != nil {
-			log.Debugf("ADB doesn't exist at %s", a.ExePath)
-			return errors.New("Impossible to find ADB")
-		}
+	// Fall back to the bundled binary. Extract it (and the required DLLs) into
+	// a temp directory so we never try to write next to the executable (which
+	// may be a read-only system path).
+	tmpDir, err := os.MkdirTemp("", "androidqf-adb-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir for adb: %v", err)
 	}
+
+	if err := assets.DeployAssetsToDir(tmpDir); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to deploy bundled adb: %v", err)
+	}
+
+	// Need full path to bypass Go 1.19+ restrictions about relative executable paths.
+	exePath := filepath.Join(tmpDir, "adb.exe")
+	if _, err := os.Stat(exePath); err != nil {
+		os.RemoveAll(tmpDir)
+		log.Debugf("ADB doesn't exist at %s", exePath)
+		return errors.New("impossible to find ADB")
+	}
+
+	a.ExePath = exePath
+	a.TmpAssetsDir = tmpDir
 	return nil
 }

--- a/adb/adb_windows.go
+++ b/adb/adb_windows.go
@@ -1,3 +1,5 @@
+//go:build !unbundle
+
 // androidqf - Android Quick Forensics
 // Copyright (c) 2021-2022 Claudio Guarnieri.
 // Use of this software is governed by the MVT License 1.1 that can be found at
@@ -9,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/mvt-project/androidqf/assets"
@@ -17,15 +18,9 @@ import (
 )
 
 func (a *ADB) findExe() error {
-	// Prefer a system-installed adb (covers distro packages where adb is on PATH).
-	if path, err := exec.LookPath("adb.exe"); err == nil {
-		a.ExePath = path
-		return nil
-	}
-
-	// Fall back to the bundled binary. Extract it (and the required DLLs) into
-	// a temp directory so we never try to write next to the executable (which
-	// may be a read-only system path).
+	// Extract the bundled binary (and the required DLLs) into a temp directory
+	// so we never try to write next to the executable (which may be a read-only
+	// system path).
 	tmpDir, err := os.MkdirTemp("", "androidqf-adb-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp dir for adb: %v", err)
@@ -45,6 +40,10 @@ func (a *ADB) findExe() error {
 	}
 
 	a.ExePath = exePath
+	if err := validatePlatformToolsVersion(a.ExePath); err != nil {
+		os.RemoveAll(tmpDir)
+		return err
+	}
 	a.TmpAssetsDir = tmpDir
 	return nil
 }

--- a/adb/collector.go
+++ b/adb/collector.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/mvt-project/androidqf/log"
-
 	"github.com/mvt-project/androidqf/assets"
 )
 
@@ -112,13 +111,32 @@ func (c *Collector) Install() error {
 	}
 
 	log.Debugf("Deploying collector binary '%s' for architecture '%s'.", collectorName, c.Architecture)
-	collectorBinary, err := assets.Collector.ReadFile(collectorName)
-	if err != nil {
-		// Somehow the file doesn't exist
-		return errors.New("couldn't find the collector binary")
+
+	// If the caller has pointed us at a directory of pre-built collector
+	// binaries (e.g. a distro package placing them under
+	// /usr/lib/androidqf/android-collector/), use those in preference to the
+	// embedded assets.  This lets packagers ship the collectors separately
+	// without patching the source, while portable-binary users get the
+	// embedded fallback automatically.
+	var collectorBinary []byte
+	if collectorDir := os.Getenv("ANDROIDQF_COLLECTOR_DIR"); collectorDir != "" {
+		data, readErr := os.ReadFile(filepath.Join(collectorDir, collectorName))
+		if readErr == nil {
+			collectorBinary = data
+			log.Debugf("Using collector from ANDROIDQF_COLLECTOR_DIR: %s", collectorDir)
+		} else {
+			log.Debugf("ANDROIDQF_COLLECTOR_DIR set but could not read collector: %v — falling back to embedded", readErr)
+		}
+	}
+	if len(collectorBinary) == 0 {
+		var err error
+		collectorBinary, err = assets.Collector.ReadFile(collectorName)
+		if err != nil {
+			return errors.New("couldn't find the collector binary")
+		}
 	}
 
-	collectorTemp, _ := os.CreateTemp("", "collector_")
+	collectorTemp, err := os.CreateTemp("", "collector_")
 	if err != nil {
 		return err
 	}

--- a/adb/version.go
+++ b/adb/version.go
@@ -1,0 +1,70 @@
+// androidqf - Android Quick Forensics
+// Copyright (c) 2021-2022 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+package adb
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// minimumPlatformToolsVersion is the oldest Android SDK Platform-Tools release
+// within the supported one-year window as of 2026-05-28.
+var minimumPlatformToolsVersion = platformToolsVersion{major: 36, minor: 0, patch: 2}
+
+var platformToolsVersionRE = regexp.MustCompile(`(?m)^Version\s+([0-9]+)\.([0-9]+)\.([0-9]+)(?:[-\s]|$)`)
+
+type platformToolsVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+func validatePlatformToolsVersion(adbPath string) error {
+	out, err := exec.Command(adbPath, "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to check adb platform-tools version: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	version, err := parsePlatformToolsVersion(string(out))
+	if err != nil {
+		return err
+	}
+	if !version.isAtLeast(minimumPlatformToolsVersion) {
+		return fmt.Errorf("adb platform-tools %s is too old; need %s or newer", version, minimumPlatformToolsVersion)
+	}
+
+	return nil
+}
+
+func parsePlatformToolsVersion(output string) (platformToolsVersion, error) {
+	match := platformToolsVersionRE.FindStringSubmatch(output)
+	if match == nil {
+		return platformToolsVersion{}, fmt.Errorf("failed to parse adb platform-tools version from adb --version output")
+	}
+
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	patch, _ := strconv.Atoi(match[3])
+
+	return platformToolsVersion{major: major, minor: minor, patch: patch}, nil
+}
+
+func (v platformToolsVersion) isAtLeast(minimum platformToolsVersion) bool {
+	if v.major != minimum.major {
+		return v.major > minimum.major
+	}
+	if v.minor != minimum.minor {
+		return v.minor > minimum.minor
+	}
+	return v.patch >= minimum.patch
+}
+
+func (v platformToolsVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}

--- a/adb/version_test.go
+++ b/adb/version_test.go
@@ -1,0 +1,65 @@
+// androidqf - Android Quick Forensics
+// Copyright (c) 2021-2022 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+package adb
+
+import "testing"
+
+func TestParsePlatformToolsVersion(t *testing.T) {
+	output := `Android Debug Bridge version 1.0.41
+Version 36.0.2-14143358
+Installed as /usr/bin/adb
+Running on Linux 6.18.15-1.qubes.fc41.x86_64 (x86_64)
+`
+
+	version, err := parsePlatformToolsVersion(output)
+	if err != nil {
+		t.Fatalf("parsePlatformToolsVersion returned error: %v", err)
+	}
+
+	expected := platformToolsVersion{major: 36, minor: 0, patch: 2}
+	if version != expected {
+		t.Fatalf("expected %s, got %s", expected, version)
+	}
+}
+
+func TestParsePlatformToolsVersionRejectsMalformedOutput(t *testing.T) {
+	_, err := parsePlatformToolsVersion("Android Debug Bridge version 1.0.41")
+	if err == nil {
+		t.Fatal("expected parsePlatformToolsVersion to reject output without a platform-tools version")
+	}
+}
+
+func TestPlatformToolsVersionMinimum(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   platformToolsVersion
+		supported bool
+	}{
+		{
+			name:      "previous one year cutoff release",
+			version:   platformToolsVersion{major: 36, minor: 0, patch: 0},
+			supported: false,
+		},
+		{
+			name:      "minimum supported release",
+			version:   platformToolsVersion{major: 36, minor: 0, patch: 2},
+			supported: true,
+		},
+		{
+			name:      "newer release",
+			version:   platformToolsVersion{major: 37, minor: 0, patch: 0},
+			supported: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.version.isAtLeast(minimumPlatformToolsVersion); got != test.supported {
+				t.Fatalf("expected supported=%v for %s, got %v", test.supported, test.version, got)
+			}
+		})
+	}
+}

--- a/adb/version_unbundle_test.go
+++ b/adb/version_unbundle_test.go
@@ -1,0 +1,24 @@
+//go:build unbundle
+
+// androidqf - Android Quick Forensics
+// Copyright (c) 2021-2022 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+package adb
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestUnbundleSystemADBVersion(t *testing.T) {
+	path, err := exec.LookPath(systemADBName())
+	if err != nil {
+		t.Fatalf("unbundle builds require a package-maintained %s on PATH: %v", systemADBName(), err)
+	}
+
+	if err := validatePlatformToolsVersion(path); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-
-	saveRuntime "github.com/botherder/go-savetime/runtime"
 )
 
 //go:embed collector_*
@@ -22,55 +20,35 @@ type Asset struct {
 	Data []byte
 }
 
-// DeployAssets is used to retrieve the embedded adb binaries and store them.
-func DeployAssets() error {
-	cwd := saveRuntime.GetExecutableDirectory()
-
+// DeployAssetsToDir extracts the embedded adb binaries into the given directory.
+// If a file already exists there it is silently skipped, so calling this
+// function more than once (or concurrently) is safe.
+func DeployAssetsToDir(dir string) error {
 	for _, asset := range getAssets() {
-		assetPath := filepath.Join(cwd, asset.Name)
+		assetPath := filepath.Join(dir, asset.Name)
 
-		// If the file already exists, skip it. This avoids failing when adb
-		// is already deployed or in use by another process.
+		// Already present – skip without error.
 		if _, err := os.Stat(assetPath); err == nil {
 			continue
 		} else if !os.IsNotExist(err) {
-			// Can't determine file existence (e.g., permission error); skip deploying this asset.
+			// Permission or other stat error – skip this asset rather than abort.
 			continue
 		}
 
-		// Try to create the asset file. If creation fails (for example because
-		// the file was created between the Stat and OpenFile calls, or because
-		// the file is locked by another process), skip the asset instead of failing.
-		assetFile, err := os.OpenFile(assetPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o755)
+		// O_EXCL ensures we don't clobber a file created between Stat and here.
+		f, err := os.OpenFile(assetPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o755)
 		if err != nil {
-			// If the file exists now, just continue; otherwise skip this asset.
 			if errors.Is(err, os.ErrExist) {
 				continue
 			}
-			// Could be locked or another transient error — do not fail the whole deployment.
+			// Transient error (e.g. locked) – skip rather than abort.
 			continue
 		}
 
-		// Write and close immediately (avoid defer in a loop).
-		_, err = assetFile.Write(asset.Data)
-		assetFile.Close()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Remove assets from the local disk
-func CleanAssets() error {
-	cwd := saveRuntime.GetExecutableDirectory()
-
-	for _, asset := range getAssets() {
-		assetPath := filepath.Join(cwd, asset.Name)
-		err := os.Remove(assetPath)
-		if err != nil {
-			return err
+		_, writeErr := f.Write(asset.Data)
+		f.Close()
+		if writeErr != nil {
+			return writeErr
 		}
 	}
 


### PR DESCRIPTION

- assets: replace DeployAssets()/CleanAssets() with DeployAssetsToDir(dir) so callers control where binaries land and cleanup is simply os.RemoveAll.

- adb (all platforms): check PATH for adb first; only extract the bundled binary when no system adb is found, and extract it into os.MkdirTemp instead of next to the executable (which may be /usr/bin or read-only). Store the temp dir in ADB.TmpAssetsDir for later cleanup.

- adb: add ADB.Cleanup() that removes TmpAssetsDir; it is a no-op when the system adb was used and nothing was extracted.

- collector: before reading from the embedded assets, check the ANDROIDQF_COLLECTOR_DIR environment variable; if set and readable, use those binaries instead.  Distro packagers can point this at /usr/lib/androidqf/android-collector/; portable-binary users get the embedded fallback automatically.

- acquisition: replace assets.CleanAssets() with adb.Client.Cleanup().

Addresses the issues raised in [mvt-project/androidqf#79](https://github.com/mvt-project/androidqf/issues/79) without breaking the portable-binary use case.