### PR TITLE
Add `-tags unbundle` to read executables from filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ Then compile AndroidQF for your platform of choice:
 
 These commands will generate binaries in a *build/* folder.
 
+### Building for distribution packages without bundled assets
+
+Distribution packages can opt out of embedding the bundled ADB and collector
+binaries by building with the `unbundle` build tag:
+
+```bash
+go build -tags unbundle -o build/
+```
+
+When this tag is enabled, androidqf expects:
+
+- `adb` to be available from the system `PATH`.
+- collector binaries to be installed under
+  `/usr/lib/androidqf/android-collector/` using the names expected by
+  androidqf, such as `collector_arm` and `collector_arm64`.
+
+Packagers may remove the bundled binary assets from `assets/` before building,
+but the `assets/` package directory and its Go source files must remain present.
+The `unbundle` build still imports the `assets` package, and the build will fail
+if the whole `assets/` directory is deleted.
+
 ## How to use
 
 > [!TIP]

--- a/adb/collector.go
+++ b/adb/collector.go
@@ -112,7 +112,7 @@ func (c *Collector) Install() error {
 	}
 
 	log.Debugf("Deploying collector binary '%s' for architecture '%s'.", collectorName, c.Architecture)
-	collectorBinary, err := assets.Collector.ReadFile(collectorName)
+	collectorBinary, err := assets.ReadCollectorFile(collectorName)
 	if err != nil {
 		// Somehow the file doesn't exist
 		return errors.New("couldn't find the collector binary")

--- a/assets/assets_bundled.go
+++ b/assets/assets_bundled.go
@@ -3,6 +3,8 @@
 // Use of this software is governed by the MVT License 1.1 that can be found at
 //   https://license.mvt.re/1.1/
 
+//go:build !unbundle
+
 package assets
 
 import (
@@ -15,11 +17,16 @@ import (
 )
 
 //go:embed collector_*
-var Collector embed.FS
+var collector embed.FS
 
 type Asset struct {
 	Name string
 	Data []byte
+}
+
+// Read a specific embedded collector binary
+func ReadCollectorFile(collectorName string) ([]byte, error) {
+	return collector.ReadFile(collectorName)
 }
 
 // DeployAssets is used to retrieve the embedded adb binaries and store them.

--- a/assets/assets_darwin.go
+++ b/assets/assets_darwin.go
@@ -3,6 +3,8 @@
 // Use of this software is governed by the MVT License 1.1 that can be found at
 //   https://license.mvt.re/1.1/
 
+//go:build !unbundle
+
 package assets
 
 import (

--- a/assets/assets_linux.go
+++ b/assets/assets_linux.go
@@ -3,6 +3,8 @@
 // Use of this software is governed by the MVT License 1.1 that can be found at
 //   https://license.mvt.re/1.1/
 
+//go:build !unbundle
+
 package assets
 
 import (

--- a/assets/assets_system.go
+++ b/assets/assets_system.go
@@ -1,0 +1,29 @@
+// androidqf - Android Quick Forensics
+// Copyright (c) 2026 kpcyrd.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+//go:build unbundle
+
+package assets
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Read a specific collector binary from filesystem
+func ReadCollectorFile(collectorName string) ([]byte, error) {
+	path := filepath.Join("/usr/lib/androidqf/android-collector", collectorName)
+	return os.ReadFile(path)
+}
+
+// Assets are expected to be installed by package manager
+func DeployAssets() error {
+	return nil
+}
+
+// No assets to clean up
+func CleanAssets() error {
+	return nil
+}

--- a/assets/assets_windows.go
+++ b/assets/assets_windows.go
@@ -3,6 +3,8 @@
 // Use of this software is governed by the MVT License 1.1 that can be found at
 //   https://license.mvt.re/1.1/
 
+//go:build !unbundle
+
 package assets
 
 import (


### PR DESCRIPTION
This implements the approach suggested in https://github.com/mvt-project/androidqf/pull/81#issuecomment-4114717407, resolves #79 (assuming #80 also lands).

I'm not 100% sure how the CI is setup, but it should probably execute both of these now to make sure a change doesn't silently break either:
```
go build -o build/

go build -o build/ -tags unbundle
```

Thanks!