### PR TITLE
fix: correct inverted error check

### DIFF
--- a/adb/files.go
+++ b/adb/files.go
@@ -15,7 +15,7 @@ func (a *ADB) FindFullCommand(path string) ([]FileInfo, error) {
 	var results []FileInfo
 	out, err := a.Shell("find", fmt.Sprintf("'%s'", path), "-type", "f", "-printf", "'%T@ %m %s %u %g %p\n'", "2>", "/dev/null")
 
-	if err == nil {
+	if err != nil {
 		return results, err
 	}
 


### PR DESCRIPTION
`adb/files.go::FindFullCommand` has an inverted error check after invoking the find command via `adb shell`. The function returns early on success (with an empty results slice and a nil error), and only proceeds to parse output when the shell command failed. Net effect: every successful call returns no results, and only failed calls have their (garbage / empty) output attempted to be parsed.