### PR TITLE
Fix option: surface errors from Hashfiles instead of dropping them

### DIFF
--- a/acquisition/acquisition.go
+++ b/acquisition/acquisition.go
@@ -232,9 +232,8 @@ func (a *Acquisition) HashFiles() error {
 	defer csvFile.Close()
 
 	csvWriter := csv.NewWriter(csvFile)
-	defer csvWriter.Flush()
 
-	_ = filepath.Walk(a.StoragePath, func(filePath string, fileInfo os.FileInfo, err error) error {
+	walkErr := filepath.Walk(a.StoragePath, func(filePath string, fileInfo os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -250,15 +249,15 @@ func (a *Acquisition) HashFiles() error {
 			return err
 		}
 
-		err = csvWriter.Write([]string{filePath, sha256})
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return csvWriter.Write([]string{filePath, sha256})
 	})
 
-	return nil
+	csvWriter.Flush()
+	if err := csvWriter.Error(); err != nil {
+		return err
+	}
+
+	return walkErr
 }
 
 func (a *Acquisition) StoreInfo() error {


### PR DESCRIPTION
`acquisition.HashFiles()` is the post-acquisition pass that walks the storage directory, hashes every collected file, and writes a `hashes.csv` manifest used as the integrity record for the acquisition. The current implementation silently drops every error it could encounter, for the purposes of auditing we should log when something hasn't been hashed.