### PR TITLE
Fix logger vet format warnings

### DIFF
--- a/adb/collector.go
+++ b/adb/collector.go
@@ -149,7 +149,7 @@ func (c *Collector) Find(path string) ([]FileInfo, error) {
 	if !c.isInstalled() {
 		err := c.Install()
 		if err != nil {
-			log.Debugf("Impossible to install collector: %w", err)
+			log.Debugf("Impossible to install collector: %v", err)
 			return results, err
 		}
 	}
@@ -175,7 +175,7 @@ func (c *Collector) FindHash(path string) ([]FileInfo, error) {
 	if !c.isInstalled() {
 		err := c.Install()
 		if err != nil {
-			log.Debugf("Impossible to install collector: %w", err)
+			log.Debugf("Impossible to install collector: %v", err)
 			return results, err
 		}
 	}
@@ -200,7 +200,7 @@ func (c *Collector) Processes() ([]ProcessInfo, error) {
 	if c.isInstalled() {
 		err := c.Install()
 		if err != nil {
-			log.Debugf("Impossible to install collector: %w", err)
+			log.Debugf("Impossible to install collector: %v", err)
 			return results, err
 		}
 	}

--- a/log/logger.go
+++ b/log/logger.go
@@ -206,7 +206,7 @@ func CloseFileLog() {
 }
 
 func Debug(v ...any) {
-	log.out(DEBUG, "", v...)
+	log.out(DEBUG, "%s", fmt.Sprint(v...))
 }
 
 func Debugf(format string, v ...any) {
@@ -214,7 +214,7 @@ func Debugf(format string, v ...any) {
 }
 
 func Info(v ...any) {
-	log.out(INFO, "", v...)
+	log.out(INFO, "%s", fmt.Sprint(v...))
 }
 
 func Infof(format string, v ...any) {
@@ -222,7 +222,7 @@ func Infof(format string, v ...any) {
 }
 
 func Warning(v ...any) {
-	log.out(WARNING, "", v...)
+	log.out(WARNING, "%s", fmt.Sprint(v...))
 }
 
 func Warningf(format string, v ...any) {
@@ -230,7 +230,7 @@ func Warningf(format string, v ...any) {
 }
 
 func Error(v ...any) {
-	log.out(ERROR, "", v...)
+	log.out(ERROR, "%s", fmt.Sprint(v...))
 }
 
 func Errorf(format string, v ...any) {
@@ -242,7 +242,7 @@ func ErrorExc(desc string, err error) {
 }
 
 func Critical(v ...any) {
-	log.out(CRITICAL, "", v...)
+	log.out(CRITICAL, "%s", fmt.Sprint(v...))
 }
 
 func Criticalf(format string, v ...any) {
@@ -250,7 +250,7 @@ func Criticalf(format string, v ...any) {
 }
 
 func Fatal(v ...any) {
-	log.out(FATAL, "", v...)
+	log.out(FATAL, "%s", fmt.Sprint(v...))
 	os.Exit(1)
 }
 

--- a/modules/backup.go
+++ b/modules/backup.go
@@ -81,7 +81,7 @@ func (b *Backup) Run(acq *acquisition.Acquisition, fast bool) error {
 
 		cwd, err := os.Getwd()
 		if err != nil {
-			log.Debugf("Impossible to get current directory: %w", err)
+			log.Debugf("Impossible to get current directory: %v", err)
 			return err
 		}
 

--- a/modules/bugreport.go
+++ b/modules/bugreport.go
@@ -47,13 +47,13 @@ func (b *Bugreport) Run(acq *acquisition.Acquisition, fast bool) error {
 		// Traditional mode: create bugreport file and move to storage directory
 		err := adb.Client.Bugreport()
 		if err != nil {
-			log.Debugf("Impossible to generate bugreport: %w", err)
+			log.Debugf("Impossible to generate bugreport: %v", err)
 			return err
 		}
 
 		cwd, err := os.Getwd()
 		if err != nil {
-			log.Debugf("Impossible to get current directory: %w", err)
+			log.Debugf("Impossible to get current directory: %v", err)
 			return err
 		}
 

--- a/modules/logs.go
+++ b/modules/logs.go
@@ -58,7 +58,7 @@ func (l *Logs) Run(acq *acquisition.Acquisition, fast bool) error {
 	for _, logFolder := range []string{"/data/anr/", "/data/log/", "/sdcard/log/"} {
 		files, err := adb.Client.ListFiles(logFolder, true)
 		if err != nil {
-			log.Debugf("Impossible to get files from %", logFolder)
+			log.Debugf("Impossible to get files from %s", logFolder)
 			continue
 		}
 		if len(files) == 0 {


### PR DESCRIPTION
## Summary

Fix Go vet failures in the logger and logging call sites so go test ./... passes on main.

The root cause was a mix of print-style logger wrappers forwarding variadic arguments through a printf-like helper with an empty format string, plus a few logging calls using %w or an incomplete % directive in non-wrapping log output.

## Changes

- Pass print-style logger arguments through fmt.Sprint with an explicit %s format.
- Replace logging-only %w directives with %v.
- Fix one malformed log format string in modules/logs.go.

## Validation

- make collector
- go test ./...