### PR TITLE
Fix ADB backup/bugreport serial handling and output path

### DIFF
--- a/adb/adb.go
+++ b/adb/adb.go
@@ -156,9 +156,14 @@ func (a *ADB) Push(localPath, remotePath string) (string, error) {
 	return string(out), nil
 }
 
-// Backup generates a backup of the specified app, or of all.
-func (a *ADB) Backup(arg string) error {
-	cmd := exec.Command(a.ExePath, "backup", "-nocompress", arg)
+// Backup generates a backup of the specified app or of all, writing the
+// archive directly to acquisition dir.
+func (a *ADB) Backup(outPath, arg string) error {
+	args := []string{"backup", "-nocompress", "-f", outPath, arg}
+	if a.Serial != "" {
+		args = append([]string{"-s", a.Serial}, args...)
+	}
+	cmd := exec.Command(a.ExePath, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, string(output))
@@ -166,9 +171,13 @@ func (a *ADB) Backup(arg string) error {
 	return nil
 }
 
-// Bugreport generates a bugreport of the the device
-func (a *ADB) Bugreport() error {
-	cmd := exec.Command(a.ExePath, "bugreport", "bugreport.zip")
+// Write bugreport directly to acquisition dir.
+func (a *ADB) Bugreport(outPath string) error {
+	args := []string{"bugreport", outPath}
+	if a.Serial != "" {
+		args = append([]string{"-s", a.Serial}, args...)
+	}
+	cmd := exec.Command(a.ExePath, args...)
 	err := cmd.Run()
 	return err
 }

--- a/modules/backup.go
+++ b/modules/backup.go
@@ -71,8 +71,7 @@ func (b *Backup) Run(acq *acquisition.Acquisition, fast bool) error {
 			return fmt.Errorf("failed to stream backup to encrypted archive: %v", err)
 		}
 	} else {
-		// Traditional mode: write directly into the per-case storage directory,
-		// avoiding the CWD temp-file collision window.
+		// Traditional mode: write backup directly into acquisition directory
 		backupPath := filepath.Join(b.StoragePath, "backup.ab")
 		err = adb.Client.Backup(backupPath, arg)
 		if err != nil {

--- a/modules/backup.go
+++ b/modules/backup.go
@@ -7,7 +7,6 @@ package modules
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/manifoldco/promptui"
@@ -72,23 +71,12 @@ func (b *Backup) Run(acq *acquisition.Acquisition, fast bool) error {
 			return fmt.Errorf("failed to stream backup to encrypted archive: %v", err)
 		}
 	} else {
-		// Traditional mode: create backup file and move to storage directory
-		err = adb.Client.Backup(arg)
+		// Traditional mode: write directly into the per-case storage directory,
+		// avoiding the CWD temp-file collision window.
+		backupPath := filepath.Join(b.StoragePath, "backup.ab")
+		err = adb.Client.Backup(backupPath, arg)
 		if err != nil {
 			log.Debugf("Impossible to get backup: %v", err)
-			return err
-		}
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			log.Debugf("Impossible to get current directory: %w", err)
-			return err
-		}
-
-		origBackupPath := filepath.Join(cwd, "backup.ab")
-		backupPath := filepath.Join(b.StoragePath, "backup.ab")
-		err = os.Rename(origBackupPath, backupPath)
-		if err != nil {
 			return err
 		}
 	}

--- a/modules/bugreport.go
+++ b/modules/bugreport.go
@@ -7,7 +7,6 @@ package modules
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/mvt-project/androidqf/acquisition"
@@ -44,23 +43,11 @@ func (b *Bugreport) Run(acq *acquisition.Acquisition, fast bool) error {
 			return fmt.Errorf("failed to stream bugreport to encrypted archive: %v", err)
 		}
 	} else {
-		// Traditional mode: create bugreport file and move to storage directory
-		err := adb.Client.Bugreport()
+		// Traditional mode: write directly into acquisition dir.
+		bugreportPath := filepath.Join(b.StoragePath, "bugreport.zip")
+		err := adb.Client.Bugreport(bugreportPath)
 		if err != nil {
 			log.Debugf("Impossible to generate bugreport: %w", err)
-			return err
-		}
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			log.Debugf("Impossible to get current directory: %w", err)
-			return err
-		}
-
-		origBugreportPath := filepath.Join(cwd, "bugreport.zip")
-		bugreportPath := filepath.Join(b.StoragePath, "bugreport.zip")
-		err = os.Rename(origBugreportPath, bugreportPath)
-		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #93 

- Prepend missing `-s <serial>` to bugreport and backup commands to work when multidevice are connected.
- Write bugreport and backup directly to acquisition directory, removing CWD temp file and rename.