### PR TITLE
Fix acquisition completion timestamp

### DIFF
--- a/acquisition/acquisition.go
+++ b/acquisition/acquisition.go
@@ -119,7 +119,9 @@ func New(path string) (*Acquisition, error) {
 }
 
 func (a *Acquisition) Complete() {
-	a.Completed = time.Now().UTC()
+	if a.Completed.IsZero() {
+		a.Completed = time.Now().UTC()
+	}
 
 	// Handle streaming mode completion
 	if a.StreamingMode && a.EncryptedWriter != nil {
@@ -180,7 +182,9 @@ func (a *Acquisition) Complete() {
 	}
 
 	// Stop ADB server before trying to remove extracted assets
-	adb.Client.KillServer()
+	if adb.Client != nil {
+		adb.Client.KillServer()
+	}
 	assets.CleanAssets()
 }
 
@@ -269,6 +273,10 @@ func (a *Acquisition) StoreInfo() error {
 	// In streaming mode, info is stored during Complete()
 	if a.StreamingMode {
 		return nil
+	}
+
+	if a.Completed.IsZero() {
+		a.Completed = time.Now().UTC()
 	}
 
 	log.Info("Saving details about acquisition and device...")

--- a/acquisition/acquisition_test.go
+++ b/acquisition/acquisition_test.go
@@ -1,0 +1,54 @@
+package acquisition
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreInfoSetsCompletedTimestamp(t *testing.T) {
+	acq := &Acquisition{
+		UUID:        "test-acquisition",
+		StoragePath: t.TempDir(),
+	}
+
+	if err := acq.StoreInfo(); err != nil {
+		t.Fatalf("StoreInfo() error = %v", err)
+	}
+
+	if acq.Completed.IsZero() {
+		t.Fatal("StoreInfo() left Completed unset")
+	}
+
+	info, err := os.ReadFile(filepath.Join(acq.StoragePath, "acquisition.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(acquisition.json) error = %v", err)
+	}
+
+	var stored Acquisition
+	if err := json.Unmarshal(info, &stored); err != nil {
+		t.Fatalf("json.Unmarshal(acquisition.json) error = %v", err)
+	}
+	if stored.Completed.IsZero() {
+		t.Fatal("acquisition.json contains a zero completed timestamp")
+	}
+}
+
+func TestCompleteDoesNotOverwriteExistingCompletedTimestamp(t *testing.T) {
+	acq := &Acquisition{
+		UUID:        "test-acquisition",
+		StoragePath: t.TempDir(),
+	}
+
+	if err := acq.StoreInfo(); err != nil {
+		t.Fatalf("StoreInfo() error = %v", err)
+	}
+	completed := acq.Completed
+
+	acq.Complete()
+
+	if !acq.Completed.Equal(completed) {
+		t.Fatalf("Complete() changed Completed from %s to %s", completed, acq.Completed)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -162,7 +162,11 @@ func main() {
 			return
 		}
 
-		acq.StoreInfo()
+		err = acq.StoreInfo()
+		if err != nil {
+			log.ErrorExc("Failed to store acquisition info", err)
+			return
+		}
 
 		err = acq.StoreSecurely()
 		if err != nil {


### PR DESCRIPTION
## Summary
- Set the acquisition completion timestamp before writing `acquisition.json` in non-streaming acquisitions.
- Preserve an already recorded completion timestamp during cleanup so metadata remains consistent.
- Handle `StoreInfo` errors and add regression tests for non-zero `completed` metadata.

## Root cause
`acquisition.json` was written before `Complete()` populated `Completed`, so non-streaming acquisitions stored Go's zero timestamp (`0001-01-01T00:00:00Z`).

Fixes #85.

## Validation
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...`