### PR TITLE
Add container image build

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,58 @@
+name: Build container image
+
+on:
+    release:
+        types:
+            - published
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    container:
+        name: Build and publish container image
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set image version
+              id: version
+              run: |
+                  version="${{ github.event.release.tag_name }}"
+                  echo "version=${version#v}" >> "$GITHUB_OUTPUT"
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract container metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ghcr.io/mvt-project/androidqf
+                  tags: |
+                      type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
+                      type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }}
+                      type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+
+            - name: Build and publish
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  platforms: linux/amd64,linux/arm64
+                  push: true
+                  build-args: |
+                      VERSION=${{ steps.version.outputs.version }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.23
+
+ARG TARGETARCH=amd64
+ARG VERSION=1.8.3
+
+RUN apk add --no-cache ca-certificates gcompat libgcc wget \
+    && case "${TARGETARCH}" in \
+        amd64|arm64) ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && wget -O /usr/local/bin/androidqf \
+        "https://github.com/mvt-project/androidqf/releases/download/v${VERSION}/androidqf_linux_${TARGETARCH}_${VERSION}" \
+    && chmod +x /usr/local/bin/androidqf
+
+WORKDIR /acquisition
+
+ENTRYPOINT ["androidqf"]
+CMD ["-output", "/output"]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ but the `assets/` package directory and its Go source files must remain present.
 The `unbundle` build still imports the `assets` package, and the build will fail
 if the whole `assets/` directory is deleted.
 
+## Container image
+
+The release container image is published to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/mvt-project/androidqf:latest
+```
+
+To collect from a USB-connected Android device on Linux, pass through the USB
+bus and mount an output directory:
+
+```bash
+docker run --rm -it --privileged \
+  -v /dev/bus/usb:/dev/bus/usb \
+  -v "$(pwd)/output:/output" \
+  ghcr.io/mvt-project/androidqf:latest -fast -output /output
+```
+
+You can also build the image locally for a released version:
+
+```bash
+docker build --build-arg VERSION=1.8.3 -t androidqf .
+```
+
 ## How to use
 
 > [!TIP]


### PR DESCRIPTION
## Summary
- Add a small Alpine-based Dockerfile that downloads the released Linux binary for the target architecture.
- Add a GitHub Actions workflow that publishes multi-arch linux/amd64 and linux/arm64 images to GHCR when a release is published.
- Document pulling, running, and locally building the container image.

Closes #82

