### PR TITLE
Use package-friendly runtime paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Before launching androidqf you need to have the target Android device connected 
 
 Once USB debugging is enabled, you can proceed launching androidqf. It will first attempt to connect to the device over the USB bridge, which should result in the Android phone to prompt you to manually authorize the host keys. Make sure to authorize them, ideally permanently so that the prompt wouldn't appear again.
 
-Now androidqf should be executing and creating an acquisition folder at the same path you have placed your androidqf binary. At some point in the execution, androidqf will prompt you some choices: these prompts will pause the acquisition until you provide a selection, so pay attention.
+Now androidqf should be executing and creating an acquisition folder in your current working directory. At some point in the execution, androidqf will prompt you some choices: these prompts will pause the acquisition until you provide a selection, so pay attention.
 
 The following data can be extracted:
 
@@ -186,7 +186,7 @@ Ideally you should have the drive fully encrypted, but that might not always be 
 
 Alternatively, androidqf allows to encrypt each acquisition with a provided [age](https://age-encryption.org) public key. Preferably, this public key belongs to a keypair for which the end-user does not possess, or at least carry, the private key. In this way, the end-user would not be able to decrypt the acquired data even under duress.
 
-If you place a file called `key.txt` in the same folder as the androidqf executable, androidqf will automatically attempt to compress and encrypt each acquisition and delete the original unencrypted copies.
+If you place a file called `key.txt` in the current working directory, androidqf will automatically attempt to compress and encrypt each acquisition and delete the original unencrypted copies. androidqf also checks for `key.txt` in the same folder as the executable; if both files exist, the current working directory takes precedence.
 
 Once you have retrieved an encrypted acquisition file, you can decrypt it with age like so:
 

--- a/acquisition/acquisition_test.go
+++ b/acquisition/acquisition_test.go
@@ -52,3 +52,34 @@ func TestCompleteDoesNotOverwriteExistingCompletedTimestamp(t *testing.T) {
 		t.Fatalf("Complete() changed Completed from %s to %s", completed, acq.Completed)
 	}
 }
+
+func TestStoreSecurelyUsesCurrentWorkingDirectory(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	writeTestAgeKey(t, cwd)
+
+	storagePath := filepath.Join(cwd, "test-acquisition")
+	if err := os.Mkdir(storagePath, 0o755); err != nil {
+		t.Fatalf("Mkdir(storagePath) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(storagePath, "data.txt"), []byte("evidence"), 0o600); err != nil {
+		t.Fatalf("WriteFile(data.txt) error = %v", err)
+	}
+
+	acq := &Acquisition{
+		UUID:        "test-acquisition",
+		StoragePath: storagePath,
+	}
+
+	if err := acq.StoreSecurely(); err != nil {
+		t.Fatalf("StoreSecurely() error = %v", err)
+	}
+
+	wantPath := filepath.Join(cwd, "test-acquisition.zip.age")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("Stat(encrypted output) error = %v", err)
+	}
+	if _, err := os.Stat(storagePath); !os.IsNotExist(err) {
+		t.Fatalf("storage path still exists or returned unexpected error: %v", err)
+	}
+}

--- a/acquisition/encrypted_stream.go
+++ b/acquisition/encrypted_stream.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"filippo.io/age"
-	saveRuntime "github.com/botherder/go-savetime/runtime"
 	"github.com/mvt-project/androidqf/log"
 )
 
@@ -55,11 +54,17 @@ func (hw *hashingWriter) Write(p []byte) (int, error) {
 
 // NewEncryptedZipWriter creates a new encrypted zip writer if key.txt exists
 func NewEncryptedZipWriter(uuid string) (*EncryptedZipWriter, error) {
-	cwd := saveRuntime.GetExecutableDirectory()
-	keyFilePath := filepath.Join(cwd, "key.txt")
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
 
 	// Check if key file exists
-	if _, err := os.Stat(keyFilePath); os.IsNotExist(err) {
+	keyFilePath, ok, err := findAgeKeyFile()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, fmt.Errorf("key.txt not found, encrypted streaming not available")
 	}
 

--- a/acquisition/encrypted_stream_test.go
+++ b/acquisition/encrypted_stream_test.go
@@ -7,8 +7,12 @@ import (
 	"encoding/csv"
 	"encoding/hex"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"filippo.io/age"
 )
 
 func TestCreateHashListTracksPlaintextZipEntries(t *testing.T) {
@@ -91,6 +95,44 @@ func TestCreateHashListTracksPlaintextZipEntries(t *testing.T) {
 func sha256Hex(content string) string {
 	sum := sha256.Sum256([]byte(content))
 	return hex.EncodeToString(sum[:])
+}
+
+func writeTestAgeKey(t *testing.T, dir string) {
+	t.Helper()
+
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity() error = %v", err)
+	}
+
+	keyPath := filepath.Join(dir, "key.txt")
+	if err := os.WriteFile(keyPath, []byte(identity.Recipient().String()), 0o600); err != nil {
+		t.Fatalf("WriteFile(key.txt) error = %v", err)
+	}
+}
+
+func TestNewEncryptedZipWriterUsesCurrentWorkingDirectory(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	writeTestAgeKey(t, cwd)
+
+	ezw, err := NewEncryptedZipWriter("test-acquisition")
+	if err != nil {
+		t.Fatalf("NewEncryptedZipWriter() error = %v", err)
+	}
+	defer os.Remove(ezw.GetOutputPath())
+
+	if err := ezw.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	wantPath := filepath.Join(cwd, "test-acquisition.zip.age")
+	if ezw.GetOutputPath() != wantPath {
+		t.Fatalf("output path = %q, want %q", ezw.GetOutputPath(), wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("Stat(output) error = %v", err)
+	}
 }
 
 func TestValidateZipEntryName(t *testing.T) {

--- a/acquisition/key.go
+++ b/acquisition/key.go
@@ -1,0 +1,46 @@
+// androidqf - Android Quick Forensics
+// Copyright (c) 2021-2022 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+package acquisition
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const keyFileName = "key.txt"
+
+func findAgeKeyFile() (string, bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false, err
+	}
+	if keyPath, ok := findAgeKeyFileInDirs(cwd, ""); ok {
+		return keyPath, true, nil
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return "", false, err
+	}
+
+	keyPath, ok := findAgeKeyFileInDirs(cwd, filepath.Dir(exe))
+	return keyPath, ok, nil
+}
+
+func findAgeKeyFileInDirs(cwd, executableDir string) (string, bool) {
+	for _, dir := range []string{cwd, executableDir} {
+		if dir == "" {
+			continue
+		}
+
+		keyPath := filepath.Join(dir, keyFileName)
+		if _, err := os.Stat(keyPath); err == nil {
+			return keyPath, true
+		}
+	}
+
+	return "", false
+}

--- a/acquisition/key_test.go
+++ b/acquisition/key_test.go
@@ -1,0 +1,47 @@
+package acquisition
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindAgeKeyFileInDirsPrefersCurrentWorkingDirectory(t *testing.T) {
+	cwd := t.TempDir()
+	executableDir := t.TempDir()
+
+	cwdKey := filepath.Join(cwd, keyFileName)
+	executableKey := filepath.Join(executableDir, keyFileName)
+	if err := os.WriteFile(cwdKey, []byte("cwd"), 0o600); err != nil {
+		t.Fatalf("WriteFile(cwd key) error = %v", err)
+	}
+	if err := os.WriteFile(executableKey, []byte("exe"), 0o600); err != nil {
+		t.Fatalf("WriteFile(executable key) error = %v", err)
+	}
+
+	got, ok := findAgeKeyFileInDirs(cwd, executableDir)
+	if !ok {
+		t.Fatal("findAgeKeyFileInDirs() did not find a key")
+	}
+	if got != cwdKey {
+		t.Fatalf("key path = %q, want %q", got, cwdKey)
+	}
+}
+
+func TestFindAgeKeyFileInDirsFallsBackToExecutableDirectory(t *testing.T) {
+	cwd := t.TempDir()
+	executableDir := t.TempDir()
+
+	executableKey := filepath.Join(executableDir, keyFileName)
+	if err := os.WriteFile(executableKey, []byte("exe"), 0o600); err != nil {
+		t.Fatalf("WriteFile(executable key) error = %v", err)
+	}
+
+	got, ok := findAgeKeyFileInDirs(cwd, executableDir)
+	if !ok {
+		t.Fatal("findAgeKeyFileInDirs() did not find a key")
+	}
+	if got != executableKey {
+		t.Fatalf("key path = %q, want %q", got, executableKey)
+	}
+}

--- a/acquisition/secure.go
+++ b/acquisition/secure.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"filippo.io/age"
-	saveRuntime "github.com/botherder/go-savetime/runtime"
 	"github.com/mvt-project/androidqf/log"
 )
 
@@ -44,10 +43,16 @@ func (a *Acquisition) StoreSecurely() error {
 		return nil
 	}
 
-	cwd := saveRuntime.GetExecutableDirectory()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 
-	keyFilePath := filepath.Join(cwd, "key.txt")
-	if _, err := os.Stat(keyFilePath); os.IsNotExist(err) {
+	keyFilePath, ok, err := findAgeKeyFile()
+	if err != nil {
+		return err
+	}
+	if !ok {
 		return nil
 	}
 
@@ -58,7 +63,7 @@ func (a *Acquisition) StoreSecurely() error {
 
 	log.Info("Compressing the acquisition folder. This might take a while...")
 
-	err := createZipFile(a.StoragePath, zipFilePath)
+	err = createZipFile(a.StoragePath, zipFilePath)
 	if err != nil {
 		return err
 	}

--- a/adb/adb_darwin.go
+++ b/adb/adb_darwin.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (a *ADB) findExe() error {
-	err := assets.DeployAssets()
+	assetDir, err := assets.DeployAssets()
 	if err != nil {
 		return err
 	}
@@ -23,6 +23,8 @@ func (a *ADB) findExe() error {
 	if err == nil {
 		a.ExePath = adbPath
 		return nil
+	} else if assetDir != "" {
+		a.ExePath = filepath.Join(assetDir, "adb")
 	} else {
 		a.ExePath = filepath.Join(saveRuntime.GetExecutableDirectory(), "adb")
 	}

--- a/adb/adb_linux.go
+++ b/adb/adb_linux.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (a *ADB) findExe() error {
-	err := assets.DeployAssets()
+	assetDir, err := assets.DeployAssets()
 	if err != nil {
 		return err
 	}
@@ -22,6 +22,8 @@ func (a *ADB) findExe() error {
 	adbPath, err := exec.LookPath("adb")
 	if err == nil {
 		a.ExePath = adbPath
+	} else if assetDir != "" {
+		a.ExePath = filepath.Join(assetDir, "adb")
 	} else {
 		a.ExePath = filepath.Join(saveRuntime.GetExecutableDirectory(), "adb")
 	}

--- a/adb/adb_windows.go
+++ b/adb/adb_windows.go
@@ -17,7 +17,7 @@ import (
 
 func (a *ADB) findExe() error {
 	// TODO: only deploy assets when needed
-	err := assets.DeployAssets()
+	assetDir, err := assets.DeployAssets()
 	if err != nil {
 		return err
 	}
@@ -25,6 +25,8 @@ func (a *ADB) findExe() error {
 	adbPath, err := exec.LookPath("adb.exe")
 	if err == nil {
 		a.ExePath = adbPath
+	} else if assetDir != "" {
+		a.ExePath = filepath.Join(assetDir, "adb.exe")
 	} else {
 		// Get path of the current directory
 		ex, err := os.Executable()

--- a/assets/assets_bundled.go
+++ b/assets/assets_bundled.go
@@ -12,8 +12,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-
-	saveRuntime "github.com/botherder/go-savetime/runtime"
+	"sync"
 )
 
 //go:embed collector_*
@@ -24,17 +23,32 @@ type Asset struct {
 	Data []byte
 }
 
+var (
+	deployMu    sync.Mutex
+	deployedDir string
+)
+
 // Read a specific embedded collector binary
 func ReadCollectorFile(collectorName string) ([]byte, error) {
 	return collector.ReadFile(collectorName)
 }
 
 // DeployAssets is used to retrieve the embedded adb binaries and store them.
-func DeployAssets() error {
-	cwd := saveRuntime.GetExecutableDirectory()
+func DeployAssets() (string, error) {
+	deployMu.Lock()
+	defer deployMu.Unlock()
+
+	if deployedDir != "" {
+		return deployedDir, nil
+	}
+
+	dir, err := os.MkdirTemp("", "androidqf-")
+	if err != nil {
+		return "", err
+	}
 
 	for _, asset := range getAssets() {
-		assetPath := filepath.Join(cwd, asset.Name)
+		assetPath := filepath.Join(dir, asset.Name)
 
 		// If the file already exists, skip it. This avoids failing when adb
 		// is already deployed or in use by another process.
@@ -62,24 +76,25 @@ func DeployAssets() error {
 		_, err = assetFile.Write(asset.Data)
 		assetFile.Close()
 		if err != nil {
-			return err
+			os.RemoveAll(dir)
+			return "", err
 		}
 	}
 
-	return nil
+	deployedDir = dir
+	return dir, nil
 }
 
 // Remove assets from the local disk
 func CleanAssets() error {
-	cwd := saveRuntime.GetExecutableDirectory()
+	deployMu.Lock()
+	dir := deployedDir
+	deployedDir = ""
+	deployMu.Unlock()
 
-	for _, asset := range getAssets() {
-		assetPath := filepath.Join(cwd, asset.Name)
-		err := os.Remove(assetPath)
-		if err != nil {
-			return err
-		}
+	if dir == "" {
+		return nil
 	}
 
-	return nil
+	return os.RemoveAll(dir)
 }

--- a/assets/assets_system.go
+++ b/assets/assets_system.go
@@ -18,9 +18,9 @@ func ReadCollectorFile(collectorName string) ([]byte, error) {
 	return os.ReadFile(path)
 }
 
-// Assets are expected to be installed by package manager
-func DeployAssets() error {
-	return nil
+// Assets are expected to be installed by package manager.
+func DeployAssets() (string, error) {
+	return "", nil
 }
 
 // No assets to clean up


### PR DESCRIPTION
## Summary

- Extract bundled ADB assets into a private temporary directory instead of next to the `androidqf` executable.
- Keep generated acquisition output in the current working directory, including encrypted archives.
- Look for `key.txt` in the current working directory first, then fall back to the executable directory.
- Document the new output and key lookup behavior and add focused tests.

## Why

This is better for androidqf usage when it is installed via a package manager: packaged executables usually live in read-only or shared system locations, while runtime artifacts should be written to the user's working directory or a temporary directory.
