### PR TITLE
Skip newly enabled Intrusion Logging downloads

### DIFF
--- a/modules/intrusion_logs.go
+++ b/modules/intrusion_logs.go
@@ -74,6 +74,19 @@ func (m *IL) Run(acq *acquisition.Acquisition, fast bool) error {
 		return nil
 	}
 
+	// Only collect IL data if the feature was already enabled before this module
+	// starts collection. If it is first enabled during this androidqf run, any
+	// useful data starts from that point and should be collected in a future run.
+	aapmEnabledAtStart, err := m.isAAPMEnabled()
+	if err != nil {
+		log.Debugf("Failed to check AAPM enabled state: %v", err)
+		aapmEnabledAtStart = false
+	}
+	if !aapmEnabledAtStart {
+		log.Info("Intrusion Logging is not enabled, skipping Intrusion Logging acquisition.")
+		return nil
+	}
+
 	// Ask user first
 	log.Info("Would you like to download Intrusion Logs from the device?")
 	promptIL := promptui.Select{
@@ -92,47 +105,33 @@ func (m *IL) Run(acq *acquisition.Acquisition, fast bool) error {
 		return nil
 	}
 
-	// Check whether AAPM is enabled right now. If disabled, don't start the activity
-	// or wait for a new file just pull whatever is already present.
-	// We still proceed with acquisition because older IL files may remain on disk
-	// and should be collected with user consent.
-	aapmEnabled, err := m.isAAPMEnabled()
+	// Snapshot of Intrusion Logs folder before triggering new log download
+	before, err := m.listDirSet(m.DirOnDevice)
+
 	if err != nil {
-		log.Debugf("Failed to check AAPM enabled state: %v", err)
-		aapmEnabled = false
+		log.Errorf("IL: failed to list %s: %v", m.DirOnDevice, err)
+		return nil
 	}
 
-	if aapmEnabled {
-		// Snapshot of Intrusion Logs folder before triggering new log download
-		before, err := m.listDirSet(m.DirOnDevice)
+	// Start the Activity to prompt the user to download a new Intrusion Log
+	if err := adb.Client.IL(); err != nil {
+		log.Errorf("Failed to launch intrusion detection activity: %v\n", err)
+		// Still allow pulling existing files if user wants; continue anyway.
+	}
 
-		if err != nil {
-			log.Errorf("IL: failed to list %s: %v", m.DirOnDevice, err)
-			return nil
-		}
+	log.Info("Launched the Intrusion Logging settings page.")
+	log.Info("On the device: scroll down, tap 'Access Logs', then press 'Download and Decrypt' for each listed device.\n")
 
-		// Start the Activity to prompt the user to download a new Intrusion Log
-		if err := adb.Client.IL(); err != nil {
-			log.Errorf("Failed to launch intrusion detection activity: %v\n", err)
-			// Still allow pulling existing files if user wants; continue anyway.
-		}
+	log.Info("Waiting for intrusion logs to be written to device. (Ctrl+C to skip waiting and continue acquisition)...")
+	// Watch directory (Ctrl+C cancels watch but continues acquisition)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 
-		log.Info("Launched the Intrusion Logging settings page.")
-		log.Info("On the device: scroll down, tap 'Access Logs', then press 'Download and Decrypt' for each listed device.\n")
-
-		log.Info("Waiting for intrusion logs to be written to device. (Ctrl+C to skip waiting and continue acquisition)...")
-		// Watch directory (Ctrl+C cancels watch but continues acquisition)
-		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-		defer stop()
-
-		// Pulls every 2 seconds. Stops on Ctrl+C or after 15 minutes.
-		watchErr := m.waitForNewFiles(ctx, m.DirOnDevice, before, 2*time.Second, 15*time.Minute)
-		if watchErr != nil {
-			// If user Ctrl+C, context is canceled and acquisition continues
-			log.Info("Stopped waiting, continuing with acquisition...")
-		}
-	} else {
-		log.Debug("AAPM is disabled, skipping activity launch and new file watcher (pulling existing files only).")
+	// Pulls every 2 seconds. Stops on Ctrl+C or after 15 minutes.
+	watchErr := m.waitForNewFiles(ctx, m.DirOnDevice, before, 2*time.Second, 15*time.Minute)
+	if watchErr != nil {
+		// If user Ctrl+C, context is canceled and acquisition continues
+		log.Info("Stopped waiting, continuing with acquisition...")
 	}
 
 	// Pull all files (old + new)

--- a/modules/intrusion_logs.go
+++ b/modules/intrusion_logs.go
@@ -74,17 +74,27 @@ func (m *IL) Run(acq *acquisition.Acquisition, fast bool) error {
 		return nil
 	}
 
-	// Only collect IL data if the feature was already enabled before this module
-	// starts collection. If it is first enabled during this androidqf run, any
-	// useful data starts from that point and should be collected in a future run.
-	aapmEnabledAtStart, err := m.isAAPMEnabled()
+	// Check whether AAPM is enabled before offering to create a new log download.
+	// If it is disabled, existing logs can still be collected, but we must not
+	// launch the download activity or wait for new files.
+	aapmEnabled, err := m.isAAPMEnabled()
 	if err != nil {
 		log.Debugf("Failed to check AAPM enabled state: %v", err)
-		aapmEnabledAtStart = false
+		aapmEnabled = false
 	}
-	if !aapmEnabledAtStart {
-		log.Info("Intrusion Logging is not enabled, skipping Intrusion Logging acquisition.")
-		return nil
+
+	var existingFiles []string
+	if !aapmEnabled {
+		existingFiles, err = adb.Client.ListFiles(m.DirOnDevice, true)
+		if err != nil {
+			log.Errorf("IL: failed to list files in %s: %v", m.DirOnDevice, err)
+			return nil
+		}
+		existingFiles = m.deviceFiles(existingFiles)
+		if len(existingFiles) == 0 {
+			log.Info("Intrusion Logging is disabled and no existing Intrusion Logs were found.")
+			return nil
+		}
 	}
 
 	// Ask user first
@@ -102,6 +112,16 @@ func (m *IL) Run(acq *acquisition.Acquisition, fast bool) error {
 	// User declined so we continue acquisition normally
 	if ILOption == skipIL {
 		log.Info("Skipping Intrusion Logging extraction...")
+		return nil
+	}
+
+	if !aapmEnabled {
+		if err := m.pullAll(acq, existingFiles); err != nil {
+			log.Errorf("IL: failed pulling IL files: %v", err)
+			return nil
+		}
+		log.Infof("Downloaded %d Intrusion Logging files from the phone.", len(existingFiles))
+		log.Info("Intrusion Logging acquisition is completed; continuing with acquisition ...")
 		return nil
 	}
 
@@ -140,6 +160,7 @@ func (m *IL) Run(acq *acquisition.Acquisition, fast bool) error {
 		log.Errorf("IL: failed to list files for pull in %s: %v", m.DirOnDevice, err)
 		return nil
 	}
+	files = m.deviceFiles(files)
 	if len(files) == 0 {
 		log.Info("No files found in " + m.DirOnDevice)
 		return nil
@@ -150,9 +171,20 @@ func (m *IL) Run(acq *acquisition.Acquisition, fast bool) error {
 		// continue acquisition
 		return nil
 	}
-	log.Infof("Downloaded %d Instrusion Logging files from the phone.", len(files))
+	log.Infof("Downloaded %d Intrusion Logging files from the phone.", len(files))
 	log.Info("Intrusion Logging acquisition is completed; continuing with acquisition ...")
 	return nil
+}
+
+// deviceFiles excludes the root directory returned by `find` when no logs exist.
+func (m *IL) deviceFiles(paths []string) []string {
+	files := make([]string, 0, len(paths))
+	for _, devicePath := range paths {
+		if _, err := relativeDeviceChild(m.DirOnDevice, devicePath); err == nil {
+			files = append(files, devicePath)
+		}
+	}
+	return files
 }
 
 func (m *IL) isAAPMCompatibleDevice() (bool, error) {


### PR DESCRIPTION
This changes the Intrusion Logging module to collect data only when AAPM/Intrusion Logging was already enabled before the module starts collection.

Previously, if the feature was enabled during an androidqf run before the later enabled-state check, the module could proceed to launch the retrieval activity and pull files. Since a first-time enable during acquisition has no prior Intrusion Logging data to retrieve, the module now skips IL acquisition in that state and leaves collection for a future run.
fixes #102 