### PR TITLE
Collect old bugreports from device

### DIFF
--- a/modules/bugreport.go
+++ b/modules/bugreport.go
@@ -7,7 +7,10 @@ package modules
 
 import (
 	"fmt"
+	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/mvt-project/androidqf/acquisition"
 	"github.com/mvt-project/androidqf/adb"
@@ -15,11 +18,22 @@ import (
 )
 
 type Bugreport struct {
-	StoragePath string
+	StoragePath       string
+	OldBugreportsPath string
 }
 
 func NewBugreport() *Bugreport {
 	return &Bugreport{}
+}
+
+var oldBugreportDeviceRoots = []string{
+	"/bugreports/",
+	"/data/user_de/0/com.android.shell/files/",
+}
+
+type oldBugreportFile struct {
+	DevicePath  string
+	ArchiveName string
 }
 
 func (b *Bugreport) Name() string {
@@ -28,10 +42,23 @@ func (b *Bugreport) Name() string {
 
 func (b *Bugreport) InitStorage(storagePath string) error {
 	b.StoragePath = storagePath
+	b.OldBugreportsPath = filepath.Join(storagePath, "old_bugreports")
+
+	if storagePath != "" {
+		err := os.Mkdir(b.OldBugreportsPath, 0o755)
+		if err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create old bugreports folder: %v", err)
+		}
+	}
+
 	return nil
 }
 
 func (b *Bugreport) Run(acq *acquisition.Acquisition, fast bool) error {
+	if err := b.pullOldBugreports(acq); err != nil {
+		log.Errorf("Failed to collect old bugreports: %v\n", err)
+	}
+
 	log.Info(
 		"Generating a bugreport for the device...",
 	)
@@ -55,4 +82,110 @@ func (b *Bugreport) Run(acq *acquisition.Acquisition, fast bool) error {
 	log.Debug("Bugreport completed!")
 
 	return nil
+}
+
+func (b *Bugreport) pullOldBugreports(acq *acquisition.Acquisition) error {
+	files := b.listOldBugreports()
+	if len(files) == 0 {
+		log.Debug("No old bugreports found on device.")
+		return nil
+	}
+
+	log.Infof("Collecting %d old bugreport files from the device...", len(files))
+
+	streaming := acq.StreamingMode && acq.EncryptedWriter != nil
+	var localRoot *os.Root
+	var puller *acquisition.StreamingPuller
+	if !streaming {
+		var err error
+		localRoot, err = os.OpenRoot(b.OldBugreportsPath)
+		if err != nil {
+			return fmt.Errorf("failed to open old bugreports output root: %v", err)
+		}
+		defer localRoot.Close()
+		puller = acquisition.NewStreamingPuller(adb.Client.ExePath, adb.Client.Serial, 100)
+	}
+
+	for _, file := range files {
+		if streaming {
+			zipPath := path.Join("old_bugreports", file.ArchiveName)
+
+			writer, err := acq.EncryptedWriter.CreateFile(zipPath)
+			if err != nil {
+				log.Errorf("Failed to create zip entry for old bugreport %s: %v\n", file.DevicePath, err)
+				continue
+			}
+
+			err = acq.StreamingPuller.PullToWriter(file.DevicePath, writer)
+			if err != nil {
+				log.Errorf("Failed to stream old bugreport %s: %v\n", file.DevicePath, err)
+				continue
+			}
+
+			log.Debugf("Streamed old bugreport %s directly to encrypted archive as %s", file.DevicePath, zipPath)
+		} else {
+			if err := streamDeviceChildToRoot(localRoot, puller, file.ArchiveName, file.DevicePath); err != nil {
+				log.Errorf("Failed to pull old bugreport %s: %v\n", file.DevicePath, err)
+				continue
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *Bugreport) listOldBugreports() []oldBugreportFile {
+	var candidates []string
+	for _, root := range oldBugreportDeviceRoots {
+		files, err := adb.Client.ListFiles(root, true)
+		if err != nil {
+			log.Debugf("Failed to list old bugreports in %s: %v", root, err)
+			continue
+		}
+		candidates = append(candidates, files...)
+	}
+
+	return uniqueOldBugreportFiles(candidates)
+}
+
+func uniqueOldBugreportFiles(devicePaths []string) []oldBugreportFile {
+	files := make([]oldBugreportFile, 0, len(devicePaths))
+	seen := make(map[string]struct{}, len(devicePaths))
+
+	for _, devicePath := range devicePaths {
+		archiveName, ok := oldBugreportArchiveName(devicePath)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[archiveName]; exists {
+			continue
+		}
+		seen[archiveName] = struct{}{}
+		files = append(files, oldBugreportFile{
+			DevicePath:  devicePath,
+			ArchiveName: archiveName,
+		})
+	}
+
+	return files
+}
+
+func oldBugreportArchiveName(devicePath string) (string, bool) {
+	if strings.ContainsRune(devicePath, 0) {
+		return "", false
+	}
+
+	name := path.Base(strings.TrimSpace(devicePath))
+	lowerName := strings.ToLower(name)
+	if name == "." || name == "/" || lowerName == "bugreports" {
+		return "", false
+	}
+	if lowerName != "bugreport.zip" && !strings.HasPrefix(lowerName, "bugreport-") {
+		return "", false
+	}
+	if !filepath.IsLocal(filepath.FromSlash(name)) {
+		return "", false
+	}
+
+	return name, true
 }

--- a/modules/bugreport_test.go
+++ b/modules/bugreport_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021-2026 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+//   https://license.mvt.re/1.1/
+
+package modules
+
+import "testing"
+
+func TestOldBugreportArchiveName(t *testing.T) {
+	tests := []struct {
+		name       string
+		devicePath string
+		want       string
+		wantOK     bool
+	}{
+		{
+			name:       "bugreport zip",
+			devicePath: "/bugreports/bugreport-bluejay-AP2A.240905.003.F1.zip",
+			want:       "bugreport-bluejay-AP2A.240905.003.F1.zip",
+			wantOK:     true,
+		},
+		{
+			name:       "plain bugreport zip",
+			devicePath: "/data/user_de/0/com.android.shell/files/bugreport.zip",
+			want:       "bugreport.zip",
+			wantOK:     true,
+		},
+		{
+			name:       "directory ignored",
+			devicePath: "/bugreports/",
+			wantOK:     false,
+		},
+		{
+			name:       "unrelated shell file ignored",
+			devicePath: "/data/user_de/0/com.android.shell/files/trace.txt",
+			wantOK:     false,
+		},
+		{
+			name:       "nul rejected",
+			devicePath: "/bugreports/bugreport-bad.zip\x00",
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := oldBugreportArchiveName(tt.devicePath)
+			if ok != tt.wantOK {
+				t.Fatalf("oldBugreportArchiveName() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("oldBugreportArchiveName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUniqueOldBugreportFilesDeduplicatesAliases(t *testing.T) {
+	files := uniqueOldBugreportFiles([]string{
+		"/bugreports/bugreport-bluejay-AP2A.240905.003.F1.zip",
+		"/data/user_de/0/com.android.shell/files/bugreports/bugreport-bluejay-AP2A.240905.003.F1.zip",
+		"/data/user_de/0/com.android.shell/files/bugreports/bugreport-a54xnsxx-TP1A.220624.014.zip",
+		"/data/user_de/0/com.android.shell/files/not-a-bugreport.txt",
+	})
+
+	if len(files) != 2 {
+		t.Fatalf("uniqueOldBugreportFiles() length = %d, want 2: %#v", len(files), files)
+	}
+	if files[0].ArchiveName != "bugreport-bluejay-AP2A.240905.003.F1.zip" {
+		t.Fatalf("first archive name = %q", files[0].ArchiveName)
+	}
+	if files[0].DevicePath != "/bugreports/bugreport-bluejay-AP2A.240905.003.F1.zip" {
+		t.Fatalf("first device path = %q", files[0].DevicePath)
+	}
+	if files[1].ArchiveName != "bugreport-a54xnsxx-TP1A.220624.014.zip" {
+		t.Fatalf("second archive name = %q", files[1].ArchiveName)
+	}
+}


### PR DESCRIPTION
This updates the bugreport collection module to pull existing bugreport artifacts from the device in addition to triggering a fresh bugreport collection.

Older bugreports can contain useful diagnostic evidence that would otherwise be missed when only the newly generated report is captured. The change adds tests covering the old bugreport discovery and collection behavior so future changes preserve that coverage.

fixes #50 