### PR TITLE
Tighten acquisition output permissions

### DIFF
--- a/acquisition/streaming_zip.go
+++ b/acquisition/streaming_zip.go
@@ -67,7 +67,7 @@ func NewStreamingZipWriter(uuid, outputDir string) (*StreamingZipWriter, error) 
 
 	stat, err := os.Stat(outputDir)
 	if os.IsNotExist(err) {
-		if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		if err := os.MkdirAll(outputDir, 0o700); err != nil {
 			return nil, fmt.Errorf("failed to create output folder: %v", err)
 		}
 	} else if err != nil {
@@ -87,7 +87,7 @@ func NewStreamingZipWriter(uuid, outputDir string) (*StreamingZipWriter, error) 
 	}
 	outputPath := filepath.Join(outputDir, fileName)
 
-	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create output file: %v", err)
 	}
@@ -305,6 +305,12 @@ func (ezw *StreamingZipWriter) Close() error {
 	if err := ezw.file.Close(); err != nil {
 		if lastErr == nil {
 			lastErr = fmt.Errorf("failed to close output file: %v", err)
+		}
+	}
+
+	if lastErr == nil {
+		if err := os.Chmod(ezw.outputPath, 0o400); err != nil {
+			lastErr = fmt.Errorf("failed to make output file read-only: %v", err)
 		}
 	}
 

--- a/acquisition/streaming_zip_test.go
+++ b/acquisition/streaming_zip_test.go
@@ -138,6 +138,64 @@ func TestNewStreamingZipWriterUsesCurrentWorkingDirectory(t *testing.T) {
 	}
 }
 
+func TestNewStreamingZipWriterUsesRestrictivePermissions(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	ezw, err := NewStreamingZipWriter("test-acquisition", outputDir)
+	if err != nil {
+		t.Fatalf("NewStreamingZipWriter() error = %v", err)
+	}
+
+	dirInfo, err := os.Stat(outputDir)
+	if err != nil {
+		t.Fatalf("Stat(output directory) error = %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got&0o077 != 0 {
+		t.Fatalf("output directory permissions = %o, want no group or world permissions", got)
+	}
+
+	fileInfo, err := os.Stat(ezw.GetOutputPath())
+	if err != nil {
+		t.Fatalf("Stat(output file) error = %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("output file permissions during acquisition = %o, want 600", got)
+	}
+
+	if err := ezw.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	fileInfo, err = os.Stat(ezw.GetOutputPath())
+	if err != nil {
+		t.Fatalf("Stat(closed output file) error = %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o400 {
+		t.Fatalf("closed output file permissions = %o, want 400", got)
+	}
+}
+
+func TestNewStreamingZipWriterDoesNotOverwriteExistingOutput(t *testing.T) {
+	outputDir := t.TempDir()
+	outputPath := filepath.Join(outputDir, "test-acquisition.zip")
+	original := []byte("existing evidence")
+	if err := os.WriteFile(outputPath, original, 0o600); err != nil {
+		t.Fatalf("WriteFile(existing output) error = %v", err)
+	}
+
+	if _, err := NewStreamingZipWriter("test-acquisition", outputDir); err == nil {
+		t.Fatal("NewStreamingZipWriter() returned nil error for existing output")
+	}
+
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(existing output) error = %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("existing output content = %q, want %q", got, original)
+	}
+}
+
 func TestValidateZipEntryName(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- create new acquisition output directories with owner-only permissions
- keep archives owner-writable during acquisition, then make them read-only after successful finalization
- refuse to overwrite an existing acquisition archive
- cover directory, in-progress archive, finalized archive, and overwrite behavior with tests

AndroidQF now streams each acquisition into a single archive, so the original directory-tree lockdown described in the issue no longer applies. This updates the hardening for the current archive output model without changing permissions on an existing user-selected output directory.

Closes #95