### PR TITLE
Trust rotated Signal signing certificate

### DIFF
--- a/utils/apks.go
+++ b/utils/apks.go
@@ -51,7 +51,8 @@ func ValidCertificates() []string {
 		"9e93b3336c767c3aba6fcc4deada9f179ee4a05b", // Candy Crush
 		"d67a8c3be07403744ef8827071a939d395dcb248", // Opera
 		"5af3c82bcdf98581f4bc98a5b86a41b30ed0c231", // Lenovo
-		"45989dc9ad8728c2aa9a82fa55503e34a8879374", // Signal
+		"45989dc9ad8728c2aa9a82fa55503e34a8879374", // Signal (legacy)
+		"5c6740091301285db5409fdcd1b90f1ac3ba2dcf", // Signal (Android 13+)
 		"47ff6ba97efaae9779356cbad5ba15233e8ddb3a", // Jitsi
 		"661952a06057ea00574a835fa4f888dd533d9f68", // TCL
 		"51478ee26ac2e3c9620a152659770c6c8ebdd1cb", // TCL

--- a/utils/apks_test.go
+++ b/utils/apks_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/avast/apkverifier"
+)
+
+func TestSignalCertificatesAreTrusted(t *testing.T) {
+	for _, sha1 := range []string{
+		"45989dc9ad8728c2aa9a82fa55503e34a8879374",
+		"5c6740091301285db5409fdcd1b90f1ac3ba2dcf",
+	} {
+		t.Run(sha1, func(t *testing.T) {
+			if !IsTrusted(apkverifier.CertInfo{Sha1: sha1}) {
+				t.Errorf("Signal certificate %s is not trusted", sha1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- trust Signal’s rotated signing certificate used for Android 13 and later
- retain the legacy Signal certificate for older installations
- cover both Signal certificate fingerprints with a regression test

## Context

Signal uses SDK-dependent signing certificates. The trusted certificate list contained only the legacy fingerprint, so current Signal APKs were retained even when trusted APK removal was selected.

Closes #108