### PR TITLE
Record ADB host public key in acquisition archives

### DIFF
--- a/acquisition/acquisition.go
+++ b/acquisition/acquisition.go
@@ -28,6 +28,7 @@ const streamingPullerMemoryLimitMB = 500
 type Acquisition struct {
 	UUID             string              `json:"uuid"`
 	AndroidQFVersion string              `json:"androidqf_version"`
+	ADBHostPublicKey string              `json:"adb_host_public_key,omitempty"`
 	StoragePath      string              `json:"storage_path"`
 	Started          time.Time           `json:"started"`
 	Completed        time.Time           `json:"completed"`
@@ -49,6 +50,11 @@ func New(path string) (*Acquisition, error) {
 		Started:          time.Now().UTC(),
 		AndroidQFVersion: utils.Version,
 		StreamingMode:    true,
+	}
+	if hostKey, err := adb.Client.HostPublicKey(); err != nil {
+		log.Warningf("Unable to record ADB host public key: %v", err)
+	} else {
+		acq.ADBHostPublicKey = hostKey
 	}
 
 	// Get system information first to get tmp folder
@@ -94,6 +100,14 @@ func (a *Acquisition) Complete() error {
 	}
 
 	if a.ZipWriter != nil {
+		if a.ADBHostPublicKey != "" {
+			err := a.ZipWriter.CreateFileFromString("adb_host_key.pub", a.ADBHostPublicKey+"\n")
+			if err != nil {
+				log.ErrorExc("Failed to store ADB host public key in archive", err)
+				completionErr = errors.Join(completionErr, fmt.Errorf("failed to store ADB host public key: %w", err))
+			}
+		}
+
 		// Store acquisition info in the zip
 		info, err := json.MarshalIndent(a, "", " ")
 		if err != nil {

--- a/acquisition/acquisition_test.go
+++ b/acquisition/acquisition_test.go
@@ -24,12 +24,13 @@ func TestCompleteWritesMetadataToStreamingZip(t *testing.T) {
 
 	started := time.Now().UTC()
 	acq := &Acquisition{
-		UUID:          "test-acquisition",
-		StoragePath:   zipWriter.GetOutputPath(),
-		Started:       started,
-		ZipWriter:     zipWriter,
-		StreamingMode: true,
-		logBuffer:     bytes.NewBufferString("logged command\n"),
+		UUID:             "test-acquisition",
+		ADBHostPublicKey: "AAAA-test-adb-public-key user@host",
+		StoragePath:      zipWriter.GetOutputPath(),
+		Started:          started,
+		ZipWriter:        zipWriter,
+		StreamingMode:    true,
+		logBuffer:        bytes.NewBufferString("logged command\n"),
 	}
 
 	if err := acq.Complete(); err != nil {
@@ -44,6 +45,9 @@ func TestCompleteWritesMetadataToStreamingZip(t *testing.T) {
 	if files["command.log"] != "logged command\n" {
 		t.Fatalf("command.log = %q", files["command.log"])
 	}
+	if files["adb_host_key.pub"] != "AAAA-test-adb-public-key user@host\n" {
+		t.Fatalf("adb_host_key.pub = %q", files["adb_host_key.pub"])
+	}
 	if _, ok := files["hashes.csv"]; !ok {
 		t.Fatal("hashes.csv missing from archive")
 	}
@@ -54,6 +58,9 @@ func TestCompleteWritesMetadataToStreamingZip(t *testing.T) {
 	}
 	if stored.Completed.IsZero() {
 		t.Fatal("acquisition.json contains a zero completed timestamp")
+	}
+	if stored.ADBHostPublicKey != acq.ADBHostPublicKey {
+		t.Fatalf("acquisition.json ADB host public key = %q, want %q", stored.ADBHostPublicKey, acq.ADBHostPublicKey)
 	}
 }
 

--- a/adb/adb_test.go
+++ b/adb/adb_test.go
@@ -33,6 +33,8 @@ func fakeADB() {
 				}
 			}
 		}
+	case "pubkey":
+		fmt.Println(os.Getenv("ANDROIDQF_FAKE_ADB_PUBLIC_KEY"))
 	default:
 		os.Exit(2)
 	}

--- a/adb/host_key.go
+++ b/adb/host_key.go
@@ -1,0 +1,55 @@
+// androidqf - Android Quick Forensics
+// Copyright (c) 2026 Claudio Guarnieri.
+// Use of this software is governed by the MVT License 1.1 that can be found at
+// https://license.mvt.re/1.1/
+
+package adb
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// HostPublicKey returns the public half of ADB's per-user host key. The private
+// key must never be copied into an acquisition archive.
+func (a *ADB) HostPublicKey() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to find user home directory: %w", err)
+	}
+
+	return a.hostPublicKey(filepath.Join(homeDir, ".android", "adbkey"))
+}
+
+func (a *ADB) hostPublicKey(privateKeyPath string) (string, error) {
+	publicKeyPath := privateKeyPath + ".pub"
+	publicKey, err := os.ReadFile(publicKeyPath)
+	if err == nil {
+		return normalizeHostPublicKey(publicKey, publicKeyPath)
+	}
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to read ADB host public key: %w", err)
+	}
+
+	// ADB normally creates adbkey.pub alongside adbkey. Derive it from the
+	// private key if the public file is missing, without exposing private data.
+	publicKey, err = exec.Command(a.ExePath, "pubkey", privateKeyPath).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to derive ADB host public key: %w", err)
+	}
+	return normalizeHostPublicKey(publicKey, publicKeyPath)
+}
+
+func normalizeHostPublicKey(publicKey []byte, source string) (string, error) {
+	key := strings.TrimSpace(string(publicKey))
+	if key == "" {
+		return "", fmt.Errorf("ADB host public key from %s is empty", source)
+	}
+	if strings.ContainsAny(key, "\r\n") {
+		return "", fmt.Errorf("ADB host public key from %s contains multiple lines", source)
+	}
+	return key, nil
+}

--- a/adb/host_key_test.go
+++ b/adb/host_key_test.go
@@ -1,0 +1,44 @@
+package adb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const testADBPublicKey = "AAAA-test-adb-public-key user@host"
+
+func TestHostPublicKeyReadsPublicKeyFile(t *testing.T) {
+	privateKeyPath := filepath.Join(t.TempDir(), "adbkey")
+	if err := os.WriteFile(privateKeyPath+".pub", []byte(testADBPublicKey+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(public key) error = %v", err)
+	}
+
+	client := &ADB{}
+	key, err := client.hostPublicKey(privateKeyPath)
+	if err != nil {
+		t.Fatalf("hostPublicKey() error = %v", err)
+	}
+	if key != testADBPublicKey {
+		t.Fatalf("hostPublicKey() = %q, want %q", key, testADBPublicKey)
+	}
+}
+
+func TestHostPublicKeyDerivesMissingPublicKey(t *testing.T) {
+	client := newFakeADB(t, "")
+	t.Setenv("ANDROIDQF_FAKE_ADB_PUBLIC_KEY", testADBPublicKey)
+
+	key, err := client.hostPublicKey(filepath.Join(t.TempDir(), "adbkey"))
+	if err != nil {
+		t.Fatalf("hostPublicKey() error = %v", err)
+	}
+	if key != testADBPublicKey {
+		t.Fatalf("hostPublicKey() = %q, want %q", key, testADBPublicKey)
+	}
+}
+
+func TestNormalizeHostPublicKeyRejectsMultipleLines(t *testing.T) {
+	if _, err := normalizeHostPublicKey([]byte("first\nsecond\n"), "test"); err == nil {
+		t.Fatal("normalizeHostPublicKey() error = nil, want multiline error")
+	}
+}

--- a/docs/acquisition-archives.md
+++ b/docs/acquisition-archives.md
@@ -26,8 +26,15 @@ The archive contains the collected module outputs documented in the main
 | Entry | Purpose |
 |---|---|
 | `acquisition.json` | Acquisition UUID, timestamps, androidqf version and device information. |
+| `adb_host_key.pub` | Public half of the ADB host key available to androidqf during the acquisition. |
 | `command.log` | Debug-level command and acquisition log, when log output was produced. |
 | `hashes.csv` | SHA-256 integrity records for preceding plaintext archive entries. |
+
+The ADB public key is also recorded in `acquisition.json`. It can be compared
+with ADB authorization records without exposing the private host key. It
+identifies the ADB host identity, not the program that initiated a connection:
+androidqf, the `adb` command-line client and other tools normally share the
+same per-user ADB key.
 
 `hashes.csv` has two CSV fields per row: the ZIP entry name and its lowercase
 SHA-256 digest. The digest covers the plaintext, uncompressed entry content.


### PR DESCRIPTION
Each acquisition now records the public half of the ADB host key as `adb_host_key.pub` and in `acquisition.json`. This allows analysts to compare an acquisition with ADB authorization records without placing the private host key in collected evidence.

AndroidQF reads the normal per-user public-key sidecar and, when it is missing, asks ADB to derive the public key from the private key. Failure to capture this supplemental metadata is reported as a warning and does not prevent collection.

The documentation clarifies that the key identifies the ADB host identity rather than a specific client program, because AndroidQF and other ADB tools normally share the same per-user key.