### PR TITLE
Fix goreleaser URL in README for version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project uses [GoReleaser](https://goreleaser.com/) for automated builds and
 
 1. Install GoReleaser:
    ```bash
-   go install github.com/goreleaser/goreleaser@v2.17.1
+   go install github.com/goreleaser/goreleaser/v2@v2.17.1
    ```
 
 2. Run a snapshot build (no publishing):


### PR DESCRIPTION
This pull request updates the installation instructions for GoReleaser in the `README.md` file to use the correct module path for version 2.x.

* Documentation update:
  * Updated the GoReleaser installation command to use `github.com/goreleaser/goreleaser/v2@v2.17.1` instead of the previous path, ensuring compatibility with Go modules for version 2.x.