### PR TITLE
Update GoReleaser documentation and installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project uses [GoReleaser](https://goreleaser.com/) for automated builds and
 
 1. Install GoReleaser:
    ```bash
-   go install github.com/goreleaser/goreleaser@v2.17.1
+   go install github.com/goreleaser/goreleaser/v2@v2.17.1
    ```
 
 2. Run a snapshot build (no publishing):

--- a/build_locally.sh
+++ b/build_locally.sh
@@ -12,7 +12,7 @@ echo ""
 # Check if goreleaser is installed
 if ! command -v goreleaser &> /dev/null; then
     echo "GoReleaser is not installed."
-    echo "Install it with: go install github.com/goreleaser/goreleaser@v2.17.1"
+    echo "Install it with: go install github.com/goreleaser/goreleaser/v2@v2.17.1"
     echo "Or see: https://goreleaser.com/install/"
     exit 1
 fi


### PR DESCRIPTION
This pull request updates the GoReleaser installation instructions to use the correct Go module path, ensuring compatibility with Go modules v2 and above.

**Documentation and script updates:**

* Updated the GoReleaser installation command in the `README.md` to use `github.com/goreleaser/goreleaser/v2@v2.17.1` instead of the deprecated path.
* Updated the installation suggestion in `build_locally.sh` to match the correct GoReleaser module path.