### PR TITLE
Collect APEX containers and inventory for offline analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,21 @@ The following data can be extracted:
 | The output of the dumpsys shell command, providing diagnostic information about the device. | | `dumpsys.txt` |
 | A list of all packages installed and related distribution files. | |  `packages.json` |
 | Copy of all installed APKs or of only those not marked as system apps. | ✅ | `apks/*` |
+| APEX inventory and complete factory and installed APEX containers for offline analysis. | | `apex/*` |
 | Intrusion Logging logs. Contains private data such as navigation history. | ✅ | `intrusion_logs/*` |
 | Installed Magisk module metadata and state markers, when existing root access is available. | ✅ | `magisk_modules/*` |
 | A list of files on the system, optionally including on-device hashes. | :white_check_mark: | `files.json` |
 | A copy of the files available in temp folders. | | `tmp/*` |
 | A bug report containing system and app-specific logs, with no private data included. | | `bugreport.zip` |
+
+The `apex` module collects complete `.apex` and `.capex` files and the device's
+APEX inventory. This preserves signing certificates, public keys and signatures
+for later analysis in MVT. AndroidQF does not verify APEX signatures, compare keys
+against known test keys, or assess vulnerability. Collection runs independently
+of the APK download and trusted-certificate removal options, and can substantially
+increase archive size and acquisition time. Use `-module apex` to collect only
+APEX evidence. See [APEX evidence](docs/apex-evidence.md) for the output format,
+root access and collection limitations.
 
 Every acquisition also contains `acquisition.json`, `command.log` when log output
 was produced, and `hashes.csv`. The hash list records the SHA-256 digest of each

--- a/docs/apex-evidence.md
+++ b/docs/apex-evidence.md
@@ -1,0 +1,70 @@
+# APEX evidence
+
+The `apex` module collects evidence for offline analysis. It does not verify
+signatures, maintain a test-key catalogue, or determine whether a device is
+vulnerable or compromised. Those assessments belong in MVT.
+
+## Collected data
+
+| Archive entry | Contents |
+| --- | --- |
+| `apex/apex-info-list.xml` | Original bytes returned for `/apex/apex-info-list.xml`, including attributes AndroidQF does not interpret. Also retained when parsing fails or the read returns partial data. |
+| `apex/manifest.json` | Schema version 1, discovery source, module metadata, file provenance and collection errors. |
+| `apex/packages.txt` | Output of `pm list packages --apex-only -f`, when fallback discovery is needed. |
+| `apex/files/<device-path-without-leading-slash>` | Complete, unmodified `.apex` and `.capex` containers. |
+
+For example, `/system/apex/com.example.apex` is saved as
+`apex/files/system/apex/com.example.apex`. Identical device paths are collected
+once; files with the same name on different partitions remain separate.
+
+Complete containers retain the APK signing material, `apex_pubkey`, payload and
+its AVB metadata. Compressed APEX files retain their embedded `original_apex`.
+Keeping the original bytes lets an offline analyzer extract keys and certificates
+or verify signatures without trusting an AndroidQF-generated verdict. Containers
+are not unpacked, executed or installed during acquisition.
+
+## Discovery and access
+
+The module uses the XML inventory to collect both `modulePath` and
+`preinstalledModulePath`. Module names, version codes, version names and available
+factory/active flags are also recorded in the JSON manifest. Missing boolean
+attributes are omitted rather than inferred. All inventory records are preserved,
+including inactive factory versions; collection is not restricted to active
+modules.
+
+If the inventory cannot be read or parsed, AndroidQF queries the package manager
+and lists the immediate entries of `/system/apex`, `/system_ext/apex`,
+`/product/apex`, `/vendor/apex`, `/odm/apex` and `/oem/apex`. This fallback may
+recover containers but cannot recover the complete XML metadata, so the module
+reports a partial collection. It does not recursively copy mounted payloads under
+`/apex` or enumerate historical/staged updates under `/data/apex`.
+
+Normal ADB access is used first. Only when a path is inaccessible does AndroidQF
+check whether `su` can already execute as UID 0. If so, it uses that access to read
+the container. It never enables or installs root. Missing or unreadable files are
+recorded individually, and collection continues with other files. Devices reporting
+an Android API level below 29 are recorded as `not_supported` and skipped.
+
+Directory entries, such as flattened APEX modules, are recorded with status
+`directory`; their contents are not copied. This records the absence of a collected
+signed container and must not be interpreted as a successful signature check.
+
+## Manifest and storage
+
+The manifest's overall status is `completed`, `partial` or `not_supported`.
+`completed` describes collection only. Each file record contains `device_path`,
+`status` (`collected`, `directory` or `failed`), and, where applicable,
+`archive_path`, `acquisition_method` (`adb` or `su`) and `error`. The separate
+`modules` list associates inventory metadata with the original device paths.
+
+APEX collection runs by default and with `-module apex`. The `-download`,
+`-remove-trusted` and `-fast` options do not suppress APEX collection. Full
+containers can substantially increase transfer time and archive size.
+
+Each transfer is staged on the host before an archive entry is created, so failed
+transfers do not leave truncated container entries. Encrypted acquisitions use
+encrypted temporary storage. Temporary storage is cleaned up after each transfer,
+and retained archive entries use the standard `hashes.csv` integrity mechanism.
+
+See the [Android APEX format documentation](https://source.android.com/docs/core/ota/apex)
+for the container formats and signing layers.

--- a/modules/apex.go
+++ b/modules/apex.go
@@ -1,0 +1,235 @@
+// androidqf - Android Quick Forensics
+// Use of this source code is governed by the MVT License 1.1
+// which can be found in the LICENSE file.
+
+package modules
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mvt-project/androidqf/acquisition"
+	"github.com/mvt-project/androidqf/adb"
+	"github.com/mvt-project/androidqf/log"
+)
+
+const apexInventoryPath = "/apex/apex-info-list.xml"
+
+var apexFactoryRoots = []string{
+	"/system/apex", "/system_ext/apex", "/product/apex",
+	"/vendor/apex", "/odm/apex", "/oem/apex",
+}
+
+type Apex struct{}
+
+func NewApex() *Apex         { return &Apex{} }
+func (a *Apex) Name() string { return "apex" }
+
+// Keep inventory relationships separately from files: a factory file can also
+// be active, and multiple inventory records can refer to the same container.
+type apexModuleInfo struct {
+	Name             string `xml:"moduleName,attr" json:"module_name"`
+	Path             string `xml:"modulePath,attr" json:"module_path"`
+	PreinstalledPath string `xml:"preinstalledModulePath,attr" json:"preinstalled_module_path,omitempty"`
+	VersionCode      string `xml:"versionCode,attr" json:"version_code,omitempty"`
+	VersionName      string `xml:"versionName,attr" json:"version_name,omitempty"`
+	IsFactory        *bool  `xml:"isFactory,attr" json:"is_factory,omitempty"`
+	IsActive         *bool  `xml:"isActive,attr" json:"is_active,omitempty"`
+}
+
+type apexInventory struct {
+	XMLName xml.Name         `xml:"apex-info-list"`
+	Modules []apexModuleInfo `xml:"apex-info"`
+}
+
+type apexFile struct {
+	DevicePath  string `json:"device_path"`
+	ArchivePath string `json:"archive_path,omitempty"`
+	Status      string `json:"status"`
+	Method      string `json:"acquisition_method,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+type apexManifest struct {
+	SchemaVersion int              `json:"schema_version"`
+	Status        string           `json:"status"`
+	Inventory     string           `json:"inventory_source,omitempty"`
+	Modules       []apexModuleInfo `json:"modules"`
+	Files         []apexFile       `json:"files"`
+	Errors        []string         `json:"errors,omitempty"`
+}
+
+func (a *Apex) Run(acq *acquisition.Acquisition, opts *Options) error {
+	if adb.Client == nil {
+		return fmt.Errorf("ADB client is unavailable")
+	}
+	manifest := apexManifest{SchemaVersion: 1, Status: "completed", Modules: []apexModuleInfo{}, Files: []apexFile{}}
+	var collectionErr error
+	recordError := func(err error) {
+		manifest.Errors = append(manifest.Errors, err.Error())
+		collectionErr = errors.Join(collectionErr, err)
+	}
+	finish := func() error {
+		var interrupted error
+		if err := opts.ContextOrBackground().Err(); err != nil {
+			if !errors.Is(collectionErr, err) {
+				recordError(err)
+			}
+			interrupted = fmt.Errorf("%w: %v", ErrAcquisitionInterrupted, err)
+		}
+		if collectionErr != nil {
+			manifest.Status = "partial"
+		}
+		return errors.Join(interrupted, partialCollectionError(collectionErr), saveDataToAcquisition(acq, "apex/manifest.json", &manifest))
+	}
+	if sdk, err := adb.Client.Shell("getprop", "ro.build.version.sdk"); err == nil {
+		if version, err := strconv.Atoi(sdk); err == nil && version > 0 && version < 29 {
+			manifest.Status = "not_supported"
+			return finish()
+		}
+	}
+	log.Info("Collecting APEX containers for offline analysis. This can increase acquisition size and duration...")
+
+	// Preserve the original inventory, including attributes not understood here.
+	raw, inventoryErr := adb.Client.Exec("exec-out", "cat", apexInventoryPath)
+	if len(raw) > 0 {
+		if err := acq.ZipWriter.CreateFileFromBytes("apex/apex-info-list.xml", raw); err != nil {
+			return err
+		}
+	}
+	var inventory apexInventory
+	if inventoryErr == nil {
+		inventoryErr = xml.Unmarshal(raw, &inventory)
+	}
+	paths := make(map[string]struct{})
+	if inventoryErr == nil {
+		manifest.Inventory = apexInventoryPath
+		manifest.Modules = append(manifest.Modules, inventory.Modules...)
+		for _, module := range inventory.Modules {
+			if module.Name == "" || module.Path == "" {
+				recordError(fmt.Errorf("APEX inventory entry is missing its module name or path"))
+			}
+			for _, devicePath := range []string{module.Path, module.PreinstalledPath} {
+				if devicePath != "" {
+					paths[devicePath] = struct{}{}
+				}
+			}
+		}
+	} else {
+		// A fallback can recover containers, but cannot reproduce all of the
+		// factory/active relationships from an unavailable or invalid inventory.
+		recordError(fmt.Errorf("read APEX inventory: %w", inventoryErr))
+		manifest.Inventory = "package_manager_and_factory_directories"
+		out, err := adb.Client.Shell("pm", "list", "packages", "--apex-only", "-f")
+		if saveErr := saveStringToAcquisition(acq, "apex/packages.txt", out); saveErr != nil {
+			return saveErr
+		}
+		if err != nil {
+			recordError(fmt.Errorf("list APEX packages: %w", err))
+		}
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "package:") {
+				continue
+			}
+			devicePath, name, ok := strings.Cut(strings.TrimPrefix(line, "package:"), "=")
+			if !ok || name == "" || devicePath == "" {
+				recordError(fmt.Errorf("malformed APEX package record %q", line))
+				continue
+			}
+			manifest.Modules = append(manifest.Modules, apexModuleInfo{Name: name, Path: devicePath})
+			paths[devicePath] = struct{}{}
+		}
+		// Fixed roots only; never walk the mounted payloads under /apex.
+		command := "for d in " + strings.Join(apexFactoryRoots, " ") + "; do " +
+			"if [ -d \"$d\" ]; then find \"$d\" -mindepth 1 -maxdepth 1 -print0 || exit; fi; done"
+		listing, err := adb.Client.Exec("shell", command)
+		if err != nil {
+			recordError(fmt.Errorf("list factory APEX directories: %w", err))
+		}
+		for _, devicePath := range strings.Split(string(listing), "\x00") {
+			if devicePath != "" {
+				paths[devicePath] = struct{}{}
+			}
+		}
+	}
+
+	ordered := make([]string, 0, len(paths))
+	for devicePath := range paths {
+		ordered = append(ordered, devicePath)
+	}
+	sort.Strings(ordered)
+	rootChecked, hasRoot := false, false
+	for _, devicePath := range ordered {
+		if err := opts.ContextOrBackground().Err(); err != nil {
+			return finish()
+		}
+		entry := apexFile{DevicePath: devicePath, Status: "failed"}
+		archivePath, err := apexArchivePath(devicePath)
+		if err == nil {
+			// Probe before staging so a failed archive write is never retried as
+			// root, which could otherwise create duplicate or incomplete entries.
+			quoted := adb.QuoteRemoteShellArg(devicePath)
+			probe := "if [ -d " + quoted + " ]; then printf directory; elif [ -f " + quoted + " ] && [ -r " + quoted + " ]; then printf file; else printf inaccessible; fi"
+			kind, probeErr := adb.Client.Shell(probe)
+			useRoot := false
+			if probeErr == nil && kind == "inaccessible" {
+				if !rootChecked {
+					hasRoot, rootChecked = adb.Client.HasRoot(), true
+				}
+				if hasRoot {
+					kind, probeErr = adb.Client.RootShell(probe)
+					useRoot = true
+				}
+			}
+			switch {
+			case probeErr != nil:
+				err = fmt.Errorf("inspect APEX path: %w", probeErr)
+			case kind == "directory":
+				entry.Status = "directory"
+				// Flattened APEX directories do not contain signed containers.
+				// Keep their inventory metadata without recursively copying them.
+			case kind != "file":
+				err = fmt.Errorf("APEX container is missing or unreadable")
+			case path.Ext(devicePath) != ".apex" && path.Ext(devicePath) != ".capex":
+				err = fmt.Errorf("unsupported APEX container extension")
+			default:
+				entry.Method = "adb"
+				if useRoot {
+					entry.Method = "su"
+					err = acq.PullRootToZipStaged(devicePath, archivePath)
+				} else {
+					err = acq.PullToZipStaged(devicePath, archivePath)
+				}
+				if err == nil {
+					entry.Status, entry.ArchivePath = "collected", archivePath
+				}
+			}
+		}
+		if err != nil {
+			entry.Error = err.Error()
+			recordError(fmt.Errorf("%s: %w", devicePath, err))
+			log.Warningf("Unable to collect APEX %s: %v", devicePath, err)
+		}
+		manifest.Files = append(manifest.Files, entry)
+	}
+	return finish()
+}
+
+func apexArchivePath(devicePath string) (string, error) {
+	if path.Clean(devicePath) != devicePath || strings.ContainsAny(devicePath, "\\\x00") {
+		return "", fmt.Errorf("unsafe APEX path %q", devicePath)
+	}
+	roots := append([]string{"/data/apex"}, apexFactoryRoots...)
+	for _, root := range roots {
+		if _, err := relativeDeviceChild(root, devicePath); err == nil {
+			return "apex/files/" + strings.TrimPrefix(devicePath, "/"), nil
+		}
+	}
+	return "", fmt.Errorf("APEX path is outside supported container directories: %q", devicePath)
+}

--- a/modules/apex_test.go
+++ b/modules/apex_test.go
@@ -1,0 +1,300 @@
+package modules
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/mvt-project/androidqf/acquisition"
+	"github.com/mvt-project/androidqf/adb"
+)
+
+const testApexInventory = `<?xml version="1.0"?>
+<apex-info-list>
+  <apex-info moduleName="com.example.test" modulePath="/data/apex/active/test.apex" preinstalledModulePath="/system/apex/test.apex" versionCode="123" isFactory="false" isActive="true" futureAttribute="preserved"/>
+  <apex-info moduleName="com.example.test" modulePath="/system/apex/test.apex" preinstalledModulePath="/system/apex/test.apex" versionCode="100" isFactory="true" isActive="false"/>
+  <apex-info moduleName="com.example.compressed" modulePath="/product/apex/test.capex" isFactory="true" isActive="true"/>
+</apex-info-list>
+`
+
+// The fake device returns opaque containers: no signature or key assessment is
+// needed to acquire them. Failures can emit bytes before exiting unsuccessfully.
+const apexFakeADB = `#!/bin/sh
+printf '%s\n' "$*" >> "$APEX_TEST_DIR/calls"
+case "$*" in
+  *"getprop ro.build.version.sdk"*) printf '%s' "${APEX_TEST_SDK:-34}" ;;
+  *"exec-out cat /apex/apex-info-list.xml"*) cat "$APEX_TEST_DIR/inventory"; exit "${APEX_TEST_INVENTORY_EXIT:-0}" ;;
+  *"pm list packages --apex-only -f"*) printf 'package:/data/apex/active/test.apex=com.example.test\n' ;;
+  *"for d in /system/apex"*) printf '/system/apex/test.apex\0/product/apex/test.capex\0' ;;
+  *"id -u"*) printf '%s' "${APEX_TEST_ROOT:-2000}" ;;
+  *"printf directory"*)
+    case "$*" in
+      *"/system/apex/flat"*) printf directory ;;
+      *"/data/apex/active/test.apex"*)
+        case "$*" in
+          *"su -c"*) printf file ;;
+          *) printf '%s' "${APEX_TEST_ACTIVE_KIND:-file}" ;;
+        esac ;;
+      *) printf file ;;
+    esac ;;
+  *"exec-out"*)
+    case "$*" in
+      *"/system/apex/test.apex"*) cat "$APEX_TEST_DIR/factory" ;;
+      *"/product/apex/test.capex"*) cat "$APEX_TEST_DIR/compressed" ;;
+      *"/data/apex/active/test.apex"*) cat "$APEX_TEST_DIR/active"; exit "${APEX_TEST_PULL_EXIT:-0}" ;;
+      *) exit 98 ;;
+    esac ;;
+  *) exit 99 ;;
+esac
+`
+
+func apexTestDevice(t *testing.T, inventory string, encrypted bool) (*acquisition.Acquisition, *age.X25519Identity) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ADB shell fixture requires Unix")
+	}
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("APEX_TEST_DIR", dir)
+	for name, data := range map[string]string{
+		"adb": apexFakeADB, "inventory": inventory,
+		"factory": "factory\x00APEX\xff", "active": "updated\x00APEX\xfe", "compressed": "compressed\x00CAPEX\xfd",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var identity *age.X25519Identity
+	if encrypted {
+		var err error
+		identity, err = age.GenerateX25519Identity()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "key.txt"), []byte(identity.Recipient().String()), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fakeADB := filepath.Join(dir, "adb")
+	old := adb.Client
+	adb.Client = &adb.ADB{ExePath: fakeADB, Serial: "apex-test-device"}
+	t.Cleanup(func() { adb.Client = old })
+	writer, err := acquisition.NewStreamingZipWriter("apex-test", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { writer.Close() })
+	acq := &acquisition.Acquisition{
+		ZipWriter: writer, StreamingMode: true,
+		StreamingPuller: acquisition.NewStreamingPuller(fakeADB, "apex-test-device", 1),
+	}
+	return acq, identity
+}
+
+func readApexTestArchive(t *testing.T, acq *acquisition.Acquisition, identity *age.X25519Identity) (apexManifest, map[string][]byte) {
+	t.Helper()
+	if err := acq.ZipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(acq.ZipWriter.GetOutputPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity != nil {
+		reader, err := age.Decrypt(bytes.NewReader(data), identity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err = io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	archive, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := make(map[string][]byte)
+	for _, file := range archive.File {
+		if _, exists := files[file.Name]; exists {
+			t.Fatalf("duplicate archive entry %q", file.Name)
+		}
+		r, err := file.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[file.Name], err = io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	var manifest apexManifest
+	if err := json.Unmarshal(files["apex/manifest.json"], &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return manifest, files
+}
+
+func TestApexPreservesContainersAndInventory(t *testing.T) {
+	for _, encrypted := range []bool{false, true} {
+		t.Run(map[bool]string{false: "plain", true: "encrypted"}[encrypted], func(t *testing.T) {
+			acq, identity := apexTestDevice(t, testApexInventory, encrypted)
+			// APK download choices must not suppress APEX evidence.
+			err := NewApex().Run(acq, &Options{NonInteractive: true, Download: apkNone, RemoveTrusted: apkRemoveTrusted})
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest, files := readApexTestArchive(t, acq, identity)
+			if manifest.Status != "completed" || len(manifest.Modules) != 3 || len(manifest.Files) != 3 {
+				t.Fatalf("unexpected manifest: %+v", manifest)
+			}
+			if manifest.Modules[0].IsActive == nil || !*manifest.Modules[0].IsActive || *manifest.Modules[0].IsFactory || manifest.Modules[0].VersionCode != "123" {
+				t.Fatalf("lost inventory relationships: %+v", manifest.Modules[0])
+			}
+			for name, want := range map[string]string{
+				"apex/apex-info-list.xml":               testApexInventory,
+				"apex/files/system/apex/test.apex":      "factory\x00APEX\xff",
+				"apex/files/data/apex/active/test.apex": "updated\x00APEX\xfe",
+				"apex/files/product/apex/test.capex":    "compressed\x00CAPEX\xfd",
+			} {
+				if string(files[name]) != want {
+					t.Fatalf("%s was not preserved byte-for-byte", name)
+				}
+			}
+			calls, err := os.ReadFile("calls")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(calls), "su -c") || strings.Contains(string(calls), "pm list") {
+				t.Fatalf("unexpected fallback commands: %s", calls)
+			}
+			for _, entry := range manifest.Files {
+				if entry.Status != "collected" || entry.Method != "adb" || files[entry.ArchivePath] == nil {
+					t.Fatalf("invalid file provenance: %+v", entry)
+				}
+			}
+		})
+	}
+}
+
+func TestApexPartialTransfersAndRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name, kind, root, pullExit string
+		partial                    bool
+	}{
+		{name: "unrooted denial", kind: "inaccessible", root: "2000", partial: true},
+		{name: "existing root", kind: "inaccessible", root: "0"},
+		{name: "truncated transfer", kind: "file", pullExit: "1", partial: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			acq, identity := apexTestDevice(t, testApexInventory, false)
+			t.Setenv("APEX_TEST_ACTIVE_KIND", tc.kind)
+			t.Setenv("APEX_TEST_ROOT", tc.root)
+			t.Setenv("APEX_TEST_PULL_EXIT", tc.pullExit)
+			err := NewApex().Run(acq, &Options{})
+			if errors.Is(err, ErrPartialCollection) != tc.partial || (!tc.partial && err != nil) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			manifest, files := readApexTestArchive(t, acq, identity)
+			_, active := files["apex/files/data/apex/active/test.apex"]
+			if active == tc.partial || files["apex/files/system/apex/test.apex"] == nil {
+				t.Fatal("failed transfer was archived or later evidence was lost")
+			}
+			entry := manifest.Files[0]
+			if tc.partial && (manifest.Status != "partial" || entry.Error == "" || entry.ArchivePath != "") {
+				t.Fatalf("failure provenance missing: %+v", manifest)
+			}
+			if tc.root == "0" && entry.Method != "su" {
+				t.Fatalf("root acquisition not recorded: %+v", entry)
+			}
+			calls, _ := os.ReadFile("calls")
+			if tc.root == "2000" && strings.Contains(string(calls), "exec-out su") {
+				t.Fatal("root transfer attempted without root")
+			}
+		})
+	}
+}
+
+func TestApexFallbackPreservesInvalidInventory(t *testing.T) {
+	for _, raw := range []string{"", "<broken>", "<unexpected/>"} {
+		t.Run(raw, func(t *testing.T) {
+			acq, identity := apexTestDevice(t, raw, false)
+			if err := NewApex().Run(acq, &Options{}); !errors.Is(err, ErrPartialCollection) {
+				t.Fatalf("expected incomplete inventory: %v", err)
+			}
+			manifest, files := readApexTestArchive(t, acq, identity)
+			if len(manifest.Files) != 3 || manifest.Inventory != "package_manager_and_factory_directories" || files["apex/packages.txt"] == nil {
+				t.Fatalf("fallback lost evidence: %+v", manifest)
+			}
+			if raw != "" && string(files["apex/apex-info-list.xml"]) != raw {
+				t.Fatal("invalid inventory was discarded")
+			}
+		})
+	}
+}
+
+func TestApexDirectoriesAndOldAndroid(t *testing.T) {
+	t.Run("flattened", func(t *testing.T) {
+		acq, identity := apexTestDevice(t, `<apex-info-list><apex-info moduleName="flat" modulePath="/system/apex/flat"/></apex-info-list>`, false)
+		if err := NewApex().Run(acq, &Options{}); err != nil {
+			t.Fatal(err)
+		}
+		manifest, files := readApexTestArchive(t, acq, identity)
+		if manifest.Files[0].Status != "directory" || len(files) != 2 {
+			t.Fatalf("flattened APEX was treated as a signed container: %+v", manifest)
+		}
+	})
+	t.Run("pre Android 10", func(t *testing.T) {
+		acq, identity := apexTestDevice(t, "", false)
+		t.Setenv("APEX_TEST_SDK", "28")
+		if err := NewApex().Run(acq, &Options{}); err != nil {
+			t.Fatal(err)
+		}
+		manifest, files := readApexTestArchive(t, acq, identity)
+		calls, _ := os.ReadFile("calls")
+		if manifest.Status != "not_supported" || len(files) != 1 || strings.Count(string(calls), "\n") != 1 {
+			t.Fatalf("unsupported device was not skipped: %+v; %s", manifest, calls)
+		}
+	})
+}
+
+func TestApexRejectsUnsafeInventoryPaths(t *testing.T) {
+	for _, devicePath := range []string{"/data/secret.apex", "/system/apex/../../secret.apex", "relative.apex", "/system/apex\\secret.apex", "/system/apex/", "/data/apex\x00/foo.apex"} {
+		if _, err := apexArchivePath(devicePath); err == nil {
+			t.Fatalf("unsafe path accepted: %q", devicePath)
+		}
+	}
+	acq, identity := apexTestDevice(t, `<apex-info-list><apex-info moduleName="bad" modulePath="/data/secret.apex"/></apex-info-list>`, false)
+	if err := NewApex().Run(acq, &Options{}); !errors.Is(err, ErrPartialCollection) {
+		t.Fatalf("unsafe inventory did not produce partial result: %v", err)
+	}
+	manifest, files := readApexTestArchive(t, acq, identity)
+	calls, _ := os.ReadFile("calls")
+	if len(files) != 2 || manifest.Files[0].Error == "" || strings.Contains(string(calls), "/data/secret.apex") {
+		t.Fatal("unsafe path was accessed or error evidence was lost")
+	}
+}
+
+func TestApexCancellationKeepsManifest(t *testing.T) {
+	acq, identity := apexTestDevice(t, testApexInventory, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := NewApex().Run(acq, &Options{Context: ctx})
+	if !errors.Is(err, ErrAcquisitionInterrupted) {
+		t.Fatalf("cancellation was not reported: %v", err)
+	}
+	manifest, _ := readApexTestArchive(t, acq, identity)
+	if manifest.Status != "partial" || len(manifest.Files) != 0 {
+		t.Fatalf("unexpected interrupted manifest: %+v", manifest)
+	}
+}

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -21,6 +21,7 @@ func List() []Module {
 		NewBackup(),
 		NewIL(),
 		NewPackages(),
+		NewApex(),
 		NewGetProp(),
 		NewDumpsys(),
 		NewProcesses(),


### PR DESCRIPTION
AndroidQF does not currently preserve APEX containers as dedicated evidence. File listings and ordinary APK collection do not provide the original APEX signing material needed for offline investigation of publicly known signing keys.

This adds an `apex` collection module that preserves complete factory and installed `.apex` and `.capex` containers alongside the original APEX inventory. Signature verification, key matching and vulnerability assessment remain the responsibility of MVT.

The module:

- Uses `/apex/apex-info-list.xml` to associate module names, versions, active/factory flags and original paths with the collected files.
- Collects both installed and preinstalled containers, deduplicating identical paths while retaining their inventory relationships.
- Falls back to the package manager and factory APEX directories when the XML inventory is unavailable or invalid, and reports that metadata coverage as partial.
- Uses ordinary ADB access first and existing `su` access only for otherwise inaccessible paths.
- Records individual collection failures and continues collecting other files. Failed transfers are not committed as container entries, and encrypted acquisitions use encrypted staging.
- Preserves `.capex` containers unchanged, including their embedded original APEX. Flattened directories are recorded without recursively copying their contents.

Collection runs by default and with `-module apex`, independently of APK download and trusted-certificate removal options. The documentation describes the output schema, collection limitations, and the additional archive size and transfer time associated with retaining complete containers.

Validation: `go test -tags unbundle ./...` passes. Added tests cover byte-for-byte preservation, duplicate paths, plain and encrypted archives, root fallback, failed transfers, invalid inventory fallback, unsafe paths, flattened directories, older Android versions and cancellation. No physical-device testing has been performed.

Related to #43. This provides evidence collection for subsequent analysis rather than implementing the issue's key checks inside AndroidQF.
